### PR TITLE
feat: v0.8.0 — Cascade pipeline + dual scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Treliq will be documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.8.0] - 2026-02-24
+
+### Changed
+- **Scoring v2: Dual scoring system** — `ideaScore` (fikir degeri, LLM-driven) ve `readinessScore` (merge hazirlik, TOPSIS-based) olarak ayristi
+- Scoring formula: `totalScore = 0.7 * ideaScore + 0.3 * readinessScore`
+- LLM prompt completely redesigned for idea value assessment with calibrated rubric
+- TOPSIS replaces weighted average for readiness scoring (evidence: MCDM literature)
+- Neutral/missing signal values now score 0 instead of 30-50
+- Contributor signal weight reduced 0.12 → 0.04 (AI agents can produce excellent PRs)
+- Intent signal removed from scoring formula (only affects weight profiles)
+
+### Added
+- Hard penalty multipliers for CI failure (0.4x), merge conflict (0.5x), spam (0.2x), draft (0.4x), abandoned (0.3x)
+- Tier classification: critical/high/normal/low based on ideaScore + readinessScore
+- Percentile rank normalization in batch scoring
+- `ideaScore`, `ideaReason`, `readinessScore`, `penaltyMultiplier`, `tier`, `percentileRank` fields on ScoredPR
+
 ## [0.7.0] - 2026-02-22
 
 ### Added
@@ -141,6 +158,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This p
 - Vision document alignment (VISION.md / ROADMAP.md check via LLM)
 - Output formats: table, JSON, markdown, GitHub comment
 
+[0.8.0]: https://github.com/mahsumaktas/treliq/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/mahsumaktas/treliq/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/mahsumaktas/treliq/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/mahsumaktas/treliq/compare/v0.5.0...v0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This p
 
 ## [0.8.0] - 2026-02-24
 
+### Added
+- **Cascade pipeline**: Heuristic pre-filter → Haiku → Sonnet re-score
+  - `readinessScore < 15 || isSpam` → skip LLM ($0)
+  - Haiku ideaScore < 40 → final (no Sonnet call)
+  - Haiku ideaScore >= 40 → Sonnet re-score for precision
+  - Estimated cost: ~$13 for 4051 PRs (vs $27 Sonnet-only)
+- `scoredBy` field: 'heuristic' | 'haiku' | 'sonnet'
+- `readyToSteal` flag: ideaScore >= 70 && implScore >= 80 && state=closed/merged
+- `noveltyBonus` field on ScoredPR
+- `CascadeConfig` and `ScoringEngineOptions` types
+- `PRData.state` field (open/closed/merged)
+- `ScoringEngine` constructor accepts options object (backward compat preserved)
+- `scoreLLM/scoreLLMSingle` accept optional provider parameter for re-scoring
+
 ### Changed
 - **Triple scoring: idea + implementation + readiness** — `ideaScore` (fikir/problem degeri, 10 LLM soru), `implementationScore` (kod kalitesi, 5 LLM soru), `readinessScore` (merge hazirlik, TOPSIS heuristic)
 - **CheckEval binary checklist** split into PART A (10 idea questions) and PART B (5 implementation questions). Evidence: CheckEval EMNLP 2025, "Rubric Is All You Need" ACM ICER 2025.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This p
 
 ### Changed
 - **Scoring v2: Dual scoring system** — `ideaScore` (fikir degeri, LLM-driven) ve `readinessScore` (merge hazirlik, TOPSIS-based) olarak ayristi
-- Scoring formula: `totalScore = 0.7 * ideaScore + 0.3 * readinessScore`
-- LLM prompt completely redesigned for idea value assessment with calibrated rubric
+- **CheckEval binary checklist** replaces single numeric LLM scoring (evidence: CheckEval EMNLP 2025, "Rubric Is All You Need" ACM ICER 2025). 15 yes/no questions for idea value — mechanically eliminates score compression.
+- **Weighted geometric mean** replaces additive formula for totalScore (evidence: Triantaphyllou 2001, PMC 729-scenario simulation). `totalScore = ideaScore^0.65 * readinessScore^0.35` with floor=5 for zero-veto protection.
+- **Few-shot calibration anchors** in LLM prompt (evidence: Zhao et al. ICML 2021). 5 reference examples spanning full score range break central tendency bias.
 - TOPSIS replaces weighted average for readiness scoring (evidence: MCDM literature)
 - Neutral/missing signal values now score 0 instead of 30-50
 - Contributor signal weight reduced 0.12 → 0.04 (AI agents can produce excellent PRs)
@@ -19,7 +20,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This p
 - Hard penalty multipliers for CI failure (0.4x), merge conflict (0.5x), spam (0.2x), draft (0.4x), abandoned (0.3x)
 - Tier classification: critical/high/normal/low based on ideaScore + readinessScore
 - Percentile rank normalization in batch scoring
-- `ideaScore`, `ideaReason`, `readinessScore`, `penaltyMultiplier`, `tier`, `percentileRank` fields on ScoredPR
+- `ideaScore`, `ideaReason`, `ideaChecklist`, `readinessScore`, `penaltyMultiplier`, `tier`, `percentileRank` fields on ScoredPR
 
 ## [0.7.0] - 2026-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,25 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This p
 ## [0.8.0] - 2026-02-24
 
 ### Changed
-- **Scoring v2: Dual scoring system** — `ideaScore` (fikir degeri, LLM-driven) ve `readinessScore` (merge hazirlik, TOPSIS-based) olarak ayristi
-- **CheckEval binary checklist** replaces single numeric LLM scoring (evidence: CheckEval EMNLP 2025, "Rubric Is All You Need" ACM ICER 2025). 15 yes/no questions for idea value — mechanically eliminates score compression.
-- **Weighted geometric mean** replaces additive formula for totalScore (evidence: Triantaphyllou 2001, PMC 729-scenario simulation). `totalScore = ideaScore^0.65 * readinessScore^0.35` with floor=5 for zero-veto protection.
-- **Few-shot calibration anchors** in LLM prompt (evidence: Zhao et al. ICML 2021). 9 reference examples spanning full score range break central tendency bias.
+- **Triple scoring: idea + implementation + readiness** — `ideaScore` (fikir/problem degeri, 10 LLM soru), `implementationScore` (kod kalitesi, 5 LLM soru), `readinessScore` (merge hazirlik, TOPSIS heuristic)
+- **CheckEval binary checklist** split into PART A (10 idea questions) and PART B (5 implementation questions). Evidence: CheckEval EMNLP 2025, "Rubric Is All You Need" ACM ICER 2025.
+- **Idea-first scoring formula**: `totalScore = 0.7 * ideaScore + 0.3 * implementationScore`. Fikir madenciligi: PR'in kodu cop olsa bile fikri degerli olabilir.
+- **Tier classification idea-driven**: critical (>=80), high (>=60), normal (>=30), low (<30) — purely based on ideaScore
+- **Few-shot calibration anchors** with dual scoring (12 references with idea/impl breakdown). Evidence: Zhao et al. ICML 2021.
 - TOPSIS replaces weighted average for readiness scoring (evidence: MCDM literature)
 - Neutral/missing signal values now score 0 instead of 30-50
 - Contributor signal weight reduced 0.12 → 0.04 (AI agents can produce excellent PRs)
 - Intent signal removed from scoring formula (only affects weight profiles)
+- Diff analysis bonus now affects `implementationScore` instead of `ideaScore`
 
 ### Added
 - Hard penalty multipliers for CI failure (0.4x), merge conflict (0.5x), spam (0.2x), draft (0.4x), abandoned (0.3x)
-- Tier classification: critical/high/normal/low based on ideaScore + readinessScore
 - Percentile rank normalization in batch scoring
-- `ideaScore`, `ideaReason`, `ideaChecklist`, `readinessScore`, `penaltyMultiplier`, `tier`, `percentileRank` fields on ScoredPR
+- `ideaScore`, `ideaReason`, `ideaChecklist`, `implementationScore`, `implementationReason`, `implementationChecklist`, `readinessScore`, `penaltyMultiplier`, `tier`, `percentileRank` fields on ScoredPR
 - **Median-of-N self-consistency** (Wang et al. 2023) — configurable multi-pass LLM scoring with median selection for variance reduction
-- **Issue context enrichment** (ContextCRBench 2025) — linked issue descriptions included in LLM prompt for +79.93% F1 improvement
+- **Issue context enrichment** (ContextCRBench 2025) — linked issue descriptions included in LLM prompt
 - `issueContext` optional field on PRData for linked issue descriptions
-- 3 new calibration anchors: community plugin docs (4/15), security config option (8/15), proactive hardening (9/15)
+- 12 dual calibration anchors spanning full score range (idea + implementation breakdown)
 
 ## [0.7.0] - 2026-02-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This p
 - **Scoring v2: Dual scoring system** — `ideaScore` (fikir degeri, LLM-driven) ve `readinessScore` (merge hazirlik, TOPSIS-based) olarak ayristi
 - **CheckEval binary checklist** replaces single numeric LLM scoring (evidence: CheckEval EMNLP 2025, "Rubric Is All You Need" ACM ICER 2025). 15 yes/no questions for idea value — mechanically eliminates score compression.
 - **Weighted geometric mean** replaces additive formula for totalScore (evidence: Triantaphyllou 2001, PMC 729-scenario simulation). `totalScore = ideaScore^0.65 * readinessScore^0.35` with floor=5 for zero-veto protection.
-- **Few-shot calibration anchors** in LLM prompt (evidence: Zhao et al. ICML 2021). 5 reference examples spanning full score range break central tendency bias.
+- **Few-shot calibration anchors** in LLM prompt (evidence: Zhao et al. ICML 2021). 9 reference examples spanning full score range break central tendency bias.
 - TOPSIS replaces weighted average for readiness scoring (evidence: MCDM literature)
 - Neutral/missing signal values now score 0 instead of 30-50
 - Contributor signal weight reduced 0.12 → 0.04 (AI agents can produce excellent PRs)
@@ -21,6 +21,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/). This p
 - Tier classification: critical/high/normal/low based on ideaScore + readinessScore
 - Percentile rank normalization in batch scoring
 - `ideaScore`, `ideaReason`, `ideaChecklist`, `readinessScore`, `penaltyMultiplier`, `tier`, `percentileRank` fields on ScoredPR
+- **Median-of-N self-consistency** (Wang et al. 2023) — configurable multi-pass LLM scoring with median selection for variance reduction
+- **Issue context enrichment** (ContextCRBench 2025) — linked issue descriptions included in LLM prompt for +79.93% F1 improvement
+- `issueContext` optional field on PRData for linked issue descriptions
+- 3 new calibration anchors: community plugin docs (4/15), security config option (8/15), proactive hardening (9/15)
 
 ## [0.7.0] - 2026-02-22
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://www.npmjs.com/package/treliq"><img src="https://img.shields.io/npm/v/treliq?style=flat-square&color=CB3837&logo=npm" alt="npm version" /></a>
   <a href="https://www.npmjs.com/package/treliq"><img src="https://img.shields.io/npm/dm/treliq?style=flat-square&color=CB3837" alt="npm downloads" /></a>
   <a href="https://github.com/mahsumaktas/treliq/actions"><img src="https://img.shields.io/github/actions/workflow/status/mahsumaktas/treliq/ci.yml?branch=main&style=flat-square" alt="CI" /></a>
-  <img src="https://img.shields.io/badge/tests-384_passing-2DA44E?style=flat-square" alt="Tests" />
+  <img src="https://img.shields.io/badge/tests-383_passing-2DA44E?style=flat-square" alt="Tests" />
   <img src="https://img.shields.io/badge/signals-21-8B5CF6?style=flat-square" alt="21 Signals" />
   <img src="https://img.shields.io/badge/providers-4-FF6600?style=flat-square" alt="4 Providers" />
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License: MIT" /></a>
@@ -51,6 +51,65 @@ npx treliq scan -r owner/repo --no-llm
 # Also scan issues alongside PRs
 npx treliq scan -r owner/repo --no-llm --include-issues
 ```
+
+## What's New in v0.8.0
+
+### Cascade Pipeline: Cost-Optimized LLM Scoring
+Three-stage pipeline that maintains Sonnet accuracy on high-value PRs while cutting total LLM cost by ~50%:
+
+```
+PR → Heuristic (21 signals + TOPSIS readiness)
+  → readinessScore < 15 || spam?  → scoredBy='heuristic', skip LLM ($0)
+  → Haiku CheckEval               → ideaScore < 40? → scoredBy='haiku', final
+  → Sonnet re-score               → scoredBy='sonnet', final (Haiku fallback on failure)
+```
+
+**Estimated cost: ~$13 for 4051 PRs** (vs $27 Sonnet-only, vs $7 Haiku-only with +7.5 bias)
+
+```bash
+# Enable cascade mode in bulk scoring
+TRELIQ_CASCADE=1 npx tsx bulk-score-openclaw.ts
+
+# Or use the ScoringEngine API directly
+const engine = new ScoringEngine({
+  provider: haikuProvider,
+  cascade: {
+    enabled: true,
+    reScoreProvider: sonnetProvider,
+    preFilterThreshold: 15,  // skip LLM below this readiness
+    haikuThreshold: 40,      // re-score with Sonnet above this ideaScore
+  },
+});
+```
+
+### Dual Scoring: Idea + Implementation + Readiness
+Three independent dimensions replace the single LLM score:
+
+| Dimension | Source | Formula |
+|-----------|--------|---------|
+| **ideaScore** (0-100) | LLM CheckEval: 10 binary questions + noveltyBonus (0-20) | `ideaYes * 8 + noveltyBonus` |
+| **implementationScore** (0-100) | LLM CheckEval: 5 binary questions | `implYes / 5 * 100` |
+| **readinessScore** (0-100) | TOPSIS heuristic (21 signals) with hard penalties | CI fail 0.4x, conflict 0.5x, spam 0.2x |
+
+**Combined**: `totalScore = 0.7 * ideaScore + 0.3 * implementationScore`
+**Tier**: critical (idea>=80), high (>=60), normal (>=30), low (<30)
+
+### New Fields on ScoredPR
+| Field | Type | Description |
+|-------|------|-------------|
+| `scoredBy` | `'heuristic' \| 'haiku' \| 'sonnet'` | Which model produced the final score |
+| `readyToSteal` | `boolean` | High-value closed PR we can re-implement (idea>=70, impl>=80, closed/merged) |
+| `noveltyBonus` | `number` | 0-20 fine-grained bonus from CheckEval Part C |
+| `ideaScore` | `number` | Idea/problem value (0-100) |
+| `implementationScore` | `number` | Code quality (0-100) |
+| `readinessScore` | `number` | Merge readiness (0-100, TOPSIS) |
+| `tier` | `string` | Priority tier (critical/high/normal/low) |
+
+### Test Suite (383 tests, 28 suites)
+- 17 new tests: cascade pipeline (8), readyToSteal (4), scoredBy (2), cascade integration (3)
+- 125/125 scoring-specific tests passing
+
+---
 
 ## What's New in v0.7.0
 
@@ -533,7 +592,7 @@ jobs:
 | 20 | PR Complexity | 0.05 | Size analysis, AI detection, overengineering |
 | 21 | **Intent** | 0.15 | bugfix/feature/refactor/dependency/docs/chore classification |
 
-When an LLM provider is configured, scores are blended: **40% heuristic + 30% LLM text + 30% LLM diff** (with diff analysis) or **40% heuristic + 60% LLM** (without diff). Intent-aware profiles automatically adjust signal weights based on PR category (e.g., bugfix PRs boost CI/test weights).
+When an LLM provider is configured, scoring uses **dual CheckEval**: `totalScore = 0.7 × ideaScore + 0.3 × implementationScore`. The `readinessScore` (TOPSIS heuristic) serves as fallback when no LLM is available and drives cascade pre-filtering. Intent-aware profiles automatically adjust signal weights based on PR category (e.g., bugfix PRs boost CI/test weights).
 
 ### 12-Signal Issue Scoring
 

--- a/bulk-score-openclaw.ts
+++ b/bulk-score-openclaw.ts
@@ -1,10 +1,10 @@
-// Bulk score candidates using treliq's ScoringEngine with LLM
+// Bulk score OpenClaw PRs using cascade pipeline: Haiku pre-filter → Sonnet re-score
+// Embedding: OpenAI text-embedding-3-small
 import { ScoringEngine } from './src/core/scoring.js';
-import { IntentClassifier } from './src/core/intent.js';
-import { createProvider } from './src/core/provider.js';
+import { createProvider, OpenAIProvider } from './src/core/provider.js';
 import { ConcurrencyController } from './src/core/concurrency.js';
 import type { PRData, ScoredPR } from './src/core/types.js';
-import { readFileSync, writeFileSync } from 'fs';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { execFileSync } from 'child_process';
 
 const CANDIDATES_FILE = process.env.TRELIQ_INPUT || '/tmp/openclaw-full-scan/treliq-input.json';
@@ -25,78 +25,101 @@ interface Candidate {
   createdAt: string;
   updatedAt: string;
   mergeable: string;
+  state?: string; // open, closed, merged
 }
 
-// Fetch detailed PR data from GitHub
-async function fetchPRDetail(prNumber: number): Promise<PRData | null> {
-  try {
-    const raw = execFileSync('gh', [
-      'api', `repos/openclaw/openclaw/pulls/${prNumber}`,
-      '--jq', JSON.stringify({
-        number: '.number',
-        title: '.title',
-        body: '(.body // "")[0:3000]',
-        author: '.user.login',
-        authorAssociation: '.author_association',
-        createdAt: '.created_at',
-        updatedAt: '.updated_at',
-        headRef: '.head.ref',
-        baseRef: '.base.ref',
-        additions: '.additions',
-        deletions: '.deletions',
-        commits: '.commits',
-        isDraft: '.draft',
-        mergeable: '.mergeable_state',
-      })
-    ], { encoding: 'utf8', maxBuffer: 1024 * 1024 });
-
-    // gh api --jq with object template doesn't work well, use raw JSON
-    return null; // Will use alternative approach
-  } catch {
-    return null;
-  }
+function mapPRState(ghPR: any): 'open' | 'closed' | 'merged' {
+  if (ghPR.merged_at || ghPR.merged) return 'merged';
+  if (ghPR.state === 'closed') return 'closed';
+  return 'open';
 }
 
 async function main() {
   const candidates: Candidate[] = JSON.parse(readFileSync(CANDIDATES_FILE, 'utf8'));
   console.error(`Loading ${candidates.length} candidates...`);
 
-  // Create provider
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
+  // Provider setup
+  const anthropicKey = process.env.ANTHROPIC_API_KEY;
+  if (!anthropicKey) {
     console.error('ANTHROPIC_API_KEY not set!');
     process.exit(1);
   }
 
-  const model = process.env.TRELIQ_MODEL || undefined;
-  const provider = createProvider('anthropic', apiKey, model);
-  const engine = new ScoringEngine(provider, false, 5);
+  const openaiKey = process.env.OPENAI_API_KEY;
+  const openaiEmbedding = openaiKey ? new OpenAIProvider(openaiKey) : undefined;
+
+  // Cascade mode: TRELIQ_CASCADE=1 enables Haiku → Sonnet pipeline
+  const cascadeEnabled = process.env.TRELIQ_CASCADE === '1';
+  const haikuModel = process.env.TRELIQ_HAIKU_MODEL || 'claude-haiku-4-5-20251001';
+  const sonnetModel = process.env.TRELIQ_SONNET_MODEL || 'claude-sonnet-4-6';
+  const preFilterThreshold = parseInt(process.env.TRELIQ_PREFILTER || '15', 10);
+  const haikuThreshold = parseInt(process.env.TRELIQ_HAIKU_THRESHOLD || '40', 10);
+
+  let engine: ScoringEngine;
+
+  if (cascadeEnabled) {
+    const haiku = createProvider('anthropic', anthropicKey, haikuModel, openaiEmbedding);
+    const sonnet = createProvider('anthropic', anthropicKey, sonnetModel, openaiEmbedding);
+    engine = new ScoringEngine({
+      provider: haiku,
+      maxConcurrent: 5,
+      cascade: {
+        enabled: true,
+        reScoreProvider: sonnet,
+        preFilterThreshold,
+        haikuThreshold,
+      },
+    });
+    console.error(`Cascade: Haiku(${haikuModel}) → Sonnet(${sonnetModel})`);
+    console.error(`Thresholds: preFilter=${preFilterThreshold}, haiku=${haikuThreshold}`);
+  } else {
+    const model = process.env.TRELIQ_MODEL || undefined;
+    const provider = createProvider('anthropic', anthropicKey, model, openaiEmbedding);
+    engine = new ScoringEngine(provider, false, 5);
+    console.error(`Single model: ${model || 'default (haiku)'}`);
+  }
+
+  if (openaiEmbedding) {
+    console.error('Embedding: OpenAI text-embedding-3-small');
+  }
+
   const cc = new ConcurrencyController(3, 2, 1000);
 
-  console.error(`Model: ${model || 'default (haiku)'}`);
-  console.error(`Concurrency: 3, retry: 2, delay: 1000ms`);
+  // Resume support: load existing results
+  let results: ScoredPR[] = [];
+  const scoredNumbers = new Set<number>();
+  if (existsSync(OUTPUT_FILE)) {
+    try {
+      const existing = JSON.parse(readFileSync(OUTPUT_FILE, 'utf8'));
+      if (existing.rankedPRs?.length > 0) {
+        results = existing.rankedPRs;
+        for (const pr of results) scoredNumbers.add(pr.number);
+        console.error(`Resuming: ${results.length} already scored, skipping...`);
+      }
+    } catch {}
+  }
 
-  // Fetch detailed data for each PR and score
+  const remaining = candidates.filter(c => !scoredNumbers.has(c.number));
+  console.error(`To score: ${remaining.length} (skipped ${candidates.length - remaining.length})`);
+
   let scored = 0;
   let failed = 0;
-  const results: ScoredPR[] = [];
-
-  // Process in batches
   const BATCH_SIZE = 10;
 
-  for (let i = 0; i < candidates.length; i += BATCH_SIZE) {
-    const batch = candidates.slice(i, i + BATCH_SIZE);
+  // Cascade stats tracking
+  const cascadeStats = { heuristic: 0, haiku: 0, sonnet: 0 };
+
+  for (let i = 0; i < remaining.length; i += BATCH_SIZE) {
+    const batch = remaining.slice(i, i + BATCH_SIZE);
     const batchPromises = batch.map(async (candidate) => {
       return cc.execute(async () => {
         try {
-          // Fetch full PR data from GitHub REST API
           const raw = execFileSync('gh', [
             'api', `repos/openclaw/openclaw/pulls/${candidate.number}`
           ], { encoding: 'utf8', maxBuffer: 2 * 1024 * 1024 });
 
           const ghPR = JSON.parse(raw);
 
-          // Fetch files
           let files: string[] = [];
           try {
             const filesRaw = execFileSync('gh', [
@@ -106,7 +129,6 @@ async function main() {
             files = filesRaw.trim().split('\n').filter(f => f);
           } catch {}
 
-          // Build PRData
           const testFiles = files.filter(f => /test|spec|__tests__/i.test(f));
           const body = (ghPR.body || '').substring(0, 3000);
           const issueRefs = body.match(/#(\d+)/g)?.map((m: string) => parseInt(m.slice(1))) || [];
@@ -143,15 +165,22 @@ async function main() {
             milestone: ghPR.milestone?.title,
             requestedReviewers: (ghPR.requested_reviewers || []).map((r: any) => r.login),
             codeowners: [],
+            state: mapPRState(ghPR),
           };
 
           const result = await engine.score(prData);
           scored++;
-          process.stderr.write(`[${scored + failed}/${candidates.length}] #${candidate.number}: score=${result.totalScore} (${result.intent})\n`);
+
+          const tag = result.scoredBy ? `[${result.scoredBy}]` : '';
+          const steal = result.readyToSteal ? ' STEAL' : '';
+          process.stderr.write(`[${scored + failed}/${remaining.length}] #${candidate.number}: score=${result.totalScore} ${tag}${steal} (${result.intent})\n`);
+
+          if (result.scoredBy) cascadeStats[result.scoredBy]++;
+
           return result;
         } catch (err: any) {
           failed++;
-          process.stderr.write(`[${scored + failed}/${candidates.length}] #${candidate.number}: FAILED - ${err.message?.substring(0, 100)}\n`);
+          process.stderr.write(`[${scored + failed}/${remaining.length}] #${candidate.number}: FAILED - ${err.message?.substring(0, 100)}\n`);
           return null;
         }
       });
@@ -165,14 +194,15 @@ async function main() {
     }
 
     // Save intermediate results every 50 PRs
-    if (results.length % 50 < BATCH_SIZE) {
+    if (scored % 50 < BATCH_SIZE) {
       writeFileSync(OUTPUT_FILE, JSON.stringify({
         scannedAt: new Date().toISOString(),
         scored: results.length,
         failed,
+        cascadeStats,
         rankedPRs: results.sort((a, b) => b.totalScore - a.totalScore),
       }, null, 2));
-      process.stderr.write(`\n--- Intermediate save: ${results.length} scored, ${failed} failed ---\n\n`);
+      process.stderr.write(`\n--- Save: ${results.length} scored, ${failed} failed | cascade: H=${cascadeStats.heuristic} K=${cascadeStats.haiku} S=${cascadeStats.sonnet} ---\n\n`);
     }
   }
 
@@ -183,17 +213,28 @@ async function main() {
     totalCandidates: candidates.length,
     scored: results.length,
     failed,
+    cascadeStats,
     rankedPRs: sorted,
   }, null, 2));
 
   console.error(`\nDone: ${results.length} scored, ${failed} failed`);
   console.error(`Results saved to ${OUTPUT_FILE}`);
 
-  // Quick summary
+  // Summary
   console.log('\n=== TRELIQ SCORING COMPLETE ===');
   console.log(`Scored: ${results.length}, Failed: ${failed}`);
-  console.log('');
-  console.log('Score distribution:');
+
+  if (cascadeEnabled) {
+    console.log(`\nCascade pipeline:`);
+    console.log(`  Heuristic (pre-filtered): ${cascadeStats.heuristic}`);
+    console.log(`  Haiku (final):            ${cascadeStats.haiku}`);
+    console.log(`  Sonnet (re-scored):       ${cascadeStats.sonnet}`);
+    const haikuCalls = cascadeStats.haiku + cascadeStats.sonnet;
+    const sonnetCalls = cascadeStats.sonnet;
+    console.log(`  LLM calls: ${haikuCalls} Haiku + ${sonnetCalls} Sonnet`);
+  }
+
+  console.log('\nScore distribution:');
   const brackets: Record<string, number> = { '90+': 0, '80-89': 0, '70-79': 0, '60-69': 0, '<60': 0 };
   for (const pr of sorted) {
     if (pr.totalScore >= 90) brackets['90+']++;
@@ -204,9 +245,27 @@ async function main() {
   }
   for (const [k, v] of Object.entries(brackets)) console.log(`  ${k}: ${v}`);
 
+  console.log('\nTier distribution:');
+  const tiers: Record<string, number> = { critical: 0, high: 0, normal: 0, low: 0 };
+  for (const pr of sorted) {
+    if (pr.tier) tiers[pr.tier]++;
+  }
+  for (const [k, v] of Object.entries(tiers)) console.log(`  ${k}: ${v}`);
+
+  // readyToSteal PRs
+  const stealable = sorted.filter(pr => pr.readyToSteal);
+  if (stealable.length > 0) {
+    console.log(`\nReady to steal (${stealable.length}):`);
+    stealable.slice(0, 20).forEach((pr, i) => {
+      console.log(`${(i+1).toString().padStart(2)}. #${pr.number} | idea=${pr.ideaScore} impl=${pr.implementationScore} | ${pr.title}`);
+    });
+  }
+
   console.log('\nTop 30:');
   sorted.slice(0, 30).forEach((pr, i) => {
-    console.log(`${(i+1).toString().padStart(2)}. #${pr.number} | Score: ${pr.totalScore} | ${pr.intent} | +${pr.additions}/-${pr.deletions}`);
+    const tag = pr.scoredBy ? `[${pr.scoredBy}]` : '';
+    const steal = pr.readyToSteal ? ' STEAL' : '';
+    console.log(`${(i+1).toString().padStart(2)}. #${pr.number} | Score: ${pr.totalScore} idea=${pr.ideaScore ?? '-'} impl=${pr.implementationScore ?? '-'} ${tag}${steal} | ${pr.intent}`);
     console.log(`    ${pr.title}`);
   });
 }

--- a/bulk-score-openclaw.ts
+++ b/bulk-score-openclaw.ts
@@ -1,0 +1,217 @@
+// Bulk score candidates using treliq's ScoringEngine with LLM
+import { ScoringEngine } from './src/core/scoring.js';
+import { IntentClassifier } from './src/core/intent.js';
+import { createProvider } from './src/core/provider.js';
+import { ConcurrencyController } from './src/core/concurrency.js';
+import type { PRData, ScoredPR } from './src/core/types.js';
+import { readFileSync, writeFileSync } from 'fs';
+import { execFileSync } from 'child_process';
+
+const CANDIDATES_FILE = process.env.TRELIQ_INPUT || '/tmp/openclaw-full-scan/treliq-input.json';
+const OUTPUT_FILE = process.env.TRELIQ_OUTPUT || '/tmp/openclaw-full-scan/treliq-scored.json';
+
+interface Candidate {
+  number: number;
+  title: string;
+  author: string;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  ci: string;
+  approved: boolean;
+  categories: string[];
+  ageDays: number;
+  labels: string[];
+  createdAt: string;
+  updatedAt: string;
+  mergeable: string;
+}
+
+// Fetch detailed PR data from GitHub
+async function fetchPRDetail(prNumber: number): Promise<PRData | null> {
+  try {
+    const raw = execFileSync('gh', [
+      'api', `repos/openclaw/openclaw/pulls/${prNumber}`,
+      '--jq', JSON.stringify({
+        number: '.number',
+        title: '.title',
+        body: '(.body // "")[0:3000]',
+        author: '.user.login',
+        authorAssociation: '.author_association',
+        createdAt: '.created_at',
+        updatedAt: '.updated_at',
+        headRef: '.head.ref',
+        baseRef: '.base.ref',
+        additions: '.additions',
+        deletions: '.deletions',
+        commits: '.commits',
+        isDraft: '.draft',
+        mergeable: '.mergeable_state',
+      })
+    ], { encoding: 'utf8', maxBuffer: 1024 * 1024 });
+
+    // gh api --jq with object template doesn't work well, use raw JSON
+    return null; // Will use alternative approach
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const candidates: Candidate[] = JSON.parse(readFileSync(CANDIDATES_FILE, 'utf8'));
+  console.error(`Loading ${candidates.length} candidates...`);
+
+  // Create provider
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    console.error('ANTHROPIC_API_KEY not set!');
+    process.exit(1);
+  }
+
+  const model = process.env.TRELIQ_MODEL || undefined;
+  const provider = createProvider('anthropic', apiKey, model);
+  const engine = new ScoringEngine(provider, false, 5);
+  const cc = new ConcurrencyController(3, 2, 1000);
+
+  console.error(`Model: ${model || 'default (haiku)'}`);
+  console.error(`Concurrency: 3, retry: 2, delay: 1000ms`);
+
+  // Fetch detailed data for each PR and score
+  let scored = 0;
+  let failed = 0;
+  const results: ScoredPR[] = [];
+
+  // Process in batches
+  const BATCH_SIZE = 10;
+
+  for (let i = 0; i < candidates.length; i += BATCH_SIZE) {
+    const batch = candidates.slice(i, i + BATCH_SIZE);
+    const batchPromises = batch.map(async (candidate) => {
+      return cc.execute(async () => {
+        try {
+          // Fetch full PR data from GitHub REST API
+          const raw = execFileSync('gh', [
+            'api', `repos/openclaw/openclaw/pulls/${candidate.number}`
+          ], { encoding: 'utf8', maxBuffer: 2 * 1024 * 1024 });
+
+          const ghPR = JSON.parse(raw);
+
+          // Fetch files
+          let files: string[] = [];
+          try {
+            const filesRaw = execFileSync('gh', [
+              'api', `repos/openclaw/openclaw/pulls/${candidate.number}/files`,
+              '--jq', '.[].filename'
+            ], { encoding: 'utf8', maxBuffer: 1024 * 1024 });
+            files = filesRaw.trim().split('\n').filter(f => f);
+          } catch {}
+
+          // Build PRData
+          const testFiles = files.filter(f => /test|spec|__tests__/i.test(f));
+          const body = (ghPR.body || '').substring(0, 3000);
+          const issueRefs = body.match(/#(\d+)/g)?.map((m: string) => parseInt(m.slice(1))) || [];
+
+          const prData: PRData = {
+            number: ghPR.number,
+            title: ghPR.title,
+            body,
+            author: ghPR.user?.login || 'unknown',
+            authorAssociation: ghPR.author_association || 'NONE',
+            createdAt: ghPR.created_at,
+            updatedAt: ghPR.updated_at,
+            headRef: ghPR.head?.ref || '',
+            baseRef: ghPR.base?.ref || 'main',
+            filesChanged: ghPR.changed_files || files.length,
+            additions: ghPR.additions || 0,
+            deletions: ghPR.deletions || 0,
+            commits: ghPR.commits || 1,
+            labels: (ghPR.labels || []).map((l: any) => l.name),
+            ciStatus: candidate.ci === 'SUCCESS' ? 'success' : 'unknown',
+            hasIssueRef: issueRefs.length > 0,
+            issueNumbers: issueRefs,
+            changedFiles: files,
+            diffUrl: ghPR.diff_url || '',
+            hasTests: testFiles.length > 0,
+            testFilesChanged: testFiles,
+            ageInDays: candidate.ageDays,
+            mergeable: candidate.mergeable === 'MERGEABLE' ? 'mergeable' :
+                       candidate.mergeable === 'CONFLICTING' ? 'conflicting' : 'unknown',
+            reviewState: candidate.approved ? 'approved' : 'none',
+            reviewCount: candidate.approved ? 1 : 0,
+            commentCount: ghPR.comments || 0,
+            isDraft: ghPR.draft || false,
+            milestone: ghPR.milestone?.title,
+            requestedReviewers: (ghPR.requested_reviewers || []).map((r: any) => r.login),
+            codeowners: [],
+          };
+
+          const result = await engine.score(prData);
+          scored++;
+          process.stderr.write(`[${scored + failed}/${candidates.length}] #${candidate.number}: score=${result.totalScore} (${result.intent})\n`);
+          return result;
+        } catch (err: any) {
+          failed++;
+          process.stderr.write(`[${scored + failed}/${candidates.length}] #${candidate.number}: FAILED - ${err.message?.substring(0, 100)}\n`);
+          return null;
+        }
+      });
+    });
+
+    const batchResults = await Promise.allSettled(batchPromises);
+    for (const r of batchResults) {
+      if (r.status === 'fulfilled' && r.value) {
+        results.push(r.value);
+      }
+    }
+
+    // Save intermediate results every 50 PRs
+    if (results.length % 50 < BATCH_SIZE) {
+      writeFileSync(OUTPUT_FILE, JSON.stringify({
+        scannedAt: new Date().toISOString(),
+        scored: results.length,
+        failed,
+        rankedPRs: results.sort((a, b) => b.totalScore - a.totalScore),
+      }, null, 2));
+      process.stderr.write(`\n--- Intermediate save: ${results.length} scored, ${failed} failed ---\n\n`);
+    }
+  }
+
+  // Final save
+  const sorted = results.sort((a, b) => b.totalScore - a.totalScore);
+  writeFileSync(OUTPUT_FILE, JSON.stringify({
+    scannedAt: new Date().toISOString(),
+    totalCandidates: candidates.length,
+    scored: results.length,
+    failed,
+    rankedPRs: sorted,
+  }, null, 2));
+
+  console.error(`\nDone: ${results.length} scored, ${failed} failed`);
+  console.error(`Results saved to ${OUTPUT_FILE}`);
+
+  // Quick summary
+  console.log('\n=== TRELIQ SCORING COMPLETE ===');
+  console.log(`Scored: ${results.length}, Failed: ${failed}`);
+  console.log('');
+  console.log('Score distribution:');
+  const brackets: Record<string, number> = { '90+': 0, '80-89': 0, '70-79': 0, '60-69': 0, '<60': 0 };
+  for (const pr of sorted) {
+    if (pr.totalScore >= 90) brackets['90+']++;
+    else if (pr.totalScore >= 80) brackets['80-89']++;
+    else if (pr.totalScore >= 70) brackets['70-79']++;
+    else if (pr.totalScore >= 60) brackets['60-69']++;
+    else brackets['<60']++;
+  }
+  for (const [k, v] of Object.entries(brackets)) console.log(`  ${k}: ${v}`);
+
+  console.log('\nTop 30:');
+  sorted.slice(0, 30).forEach((pr, i) => {
+    console.log(`${(i+1).toString().padStart(2)}. #${pr.number} | Score: ${pr.totalScore} | ${pr.intent} | +${pr.additions}/-${pr.deletions}`);
+    console.log(`    ${pr.title}`);
+  });
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/dedup-openclaw.ts
+++ b/dedup-openclaw.ts
@@ -1,0 +1,189 @@
+// Run DedupEngine on all 4051 scored openclaw PRs
+import { DedupEngine } from './src/core/dedup.js';
+import { createProvider } from './src/core/provider.js';
+import { ConcurrencyController } from './src/core/concurrency.js';
+import type { ScoredPR } from './src/core/types.js';
+import { readFileSync, writeFileSync } from 'fs';
+
+const INPUT = process.env.DEDUP_INPUT || '/tmp/openclaw-full-scan/sonnet-full-scored.json';
+const OUTPUT = process.env.DEDUP_OUTPUT || '/tmp/openclaw-full-scan/dedup-results.json';
+
+async function main() {
+  // Load scored PRs
+  const data = JSON.parse(readFileSync(INPUT, 'utf8'));
+  const prs: ScoredPR[] = data.rankedPRs;
+  console.error(`Loaded ${prs.length} scored PRs`);
+
+  // Create OpenAI provider for embeddings
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    console.error('OPENAI_API_KEY not set!');
+    process.exit(1);
+  }
+
+  const provider = createProvider('openai', apiKey);
+  console.error(`Provider: OpenAI (text-embedding-3-small)`);
+
+  // Create concurrency controller - generous for embeddings
+  const cc = new ConcurrencyController(20, 3, 500);
+
+  // Create DedupEngine
+  // Lower threshold to catch more related PRs
+  const duplicateThreshold = 0.85;
+  const relatedThreshold = 0.75;
+  const dedup = new DedupEngine(duplicateThreshold, relatedThreshold, provider);
+
+  console.error(`Thresholds: duplicate=${duplicateThreshold}, related=${relatedThreshold}`);
+  console.error(`Starting dedup on ${prs.length} PRs...`);
+  console.error('');
+
+  const startTime = Date.now();
+
+  // Run dedup WITHOUT LLM verification (too expensive for 4051 PRs)
+  const clusters = await dedup.findDuplicates(prs, cc, false);
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.error(`\nDedup complete in ${elapsed}s`);
+  console.error(`Found ${clusters.length} duplicate clusters`);
+
+  // Analyze clusters
+  const totalDuplicatePRs = clusters.reduce((sum, c) => sum + c.prs.length, 0);
+  const uniquePRs = prs.length - totalDuplicatePRs + clusters.length; // each cluster counts as 1
+
+  console.error(`Total PRs in clusters: ${totalDuplicatePRs}`);
+  console.error(`Unique PRs (after dedup): ~${uniquePRs}`);
+  console.error('');
+
+  // Check current patches for duplicates
+  const confLines = readFileSync('/Users/mahsum/.openclaw/my-patches/pr-patches.conf', 'utf8').split('\n');
+  const patchedNums = new Set<number>();
+  for (const line of confLines) {
+    const m = line.match(/^\s*(\d+)\s*\|/);
+    if (m) patchedNums.add(parseInt(m[1]));
+  }
+
+  // Find clusters containing our patches
+  const patchClusters: any[] = [];
+  for (const cluster of clusters) {
+    const patchedInCluster = cluster.prs.filter((p: any) => patchedNums.has(p.number));
+    if (patchedInCluster.length > 1) {
+      // Multiple of our patches are in the same cluster = we have duplicates!
+      patchClusters.push({
+        clusterId: cluster.id,
+        similarity: cluster.similarity,
+        bestPR: cluster.bestPR,
+        reason: cluster.reason,
+        patchedPRs: patchedInCluster.map((p: any) => ({
+          number: p.number,
+          title: p.title,
+          score: p.totalScore,
+        })),
+        allPRs: cluster.prs.map((p: any) => ({
+          number: p.number,
+          title: p.title,
+          score: p.totalScore,
+          isPatched: patchedNums.has(p.number),
+        })),
+      });
+    }
+  }
+
+  // Summary output
+  const result = {
+    scannedAt: new Date().toISOString(),
+    totalPRs: prs.length,
+    totalClusters: clusters.length,
+    totalDuplicatePRs,
+    estimatedUniquePRs: uniquePRs,
+    duplicateThreshold,
+    relatedThreshold,
+    elapsedSeconds: parseFloat(elapsed),
+
+    // Clusters with multiple patched PRs (DUPLICATES IN OUR PATCHES)
+    patchDuplicates: patchClusters,
+
+    // All clusters sorted by size
+    clustersBySize: clusters
+      .map(c => ({
+        id: c.id,
+        size: c.prs.length,
+        similarity: c.similarity,
+        bestPR: c.bestPR,
+        reason: c.reason,
+        prs: c.prs.map((p: any) => ({
+          number: p.number,
+          title: p.title,
+          score: p.totalScore,
+          isPatched: patchedNums.has(p.number),
+        })),
+      }))
+      .sort((a, b) => b.size - a.size),
+
+    // Score distribution after dedup (unique PRs only)
+    scoreDistAfterDedup: (() => {
+      const bestNums = new Set(clusters.map(c => c.bestPR));
+      const inCluster = new Set(clusters.flatMap(c => c.prs.map((p: any) => p.number)));
+      // Keep: PRs not in any cluster + best PR from each cluster
+      const uniquePRList = prs.filter(p => !inCluster.has(p.number) || bestNums.has(p.number));
+      const dist: Record<string, number> = { '80+': 0, '75-79': 0, '70-74': 0, '65-69': 0, '60-64': 0, '<60': 0 };
+      for (const p of uniquePRList) {
+        if (p.totalScore >= 80) dist['80+']++;
+        else if (p.totalScore >= 75) dist['75-79']++;
+        else if (p.totalScore >= 70) dist['70-74']++;
+        else if (p.totalScore >= 65) dist['65-69']++;
+        else if (p.totalScore >= 60) dist['60-64']++;
+        else dist['<60']++;
+      }
+      return { total: uniquePRList.length, distribution: dist };
+    })(),
+  };
+
+  writeFileSync(OUTPUT, JSON.stringify(result, null, 2));
+
+  // Console report
+  console.log('\n=== DEDUP REPORT ===');
+  console.log(`Total PRs: ${prs.length}`);
+  console.log(`Clusters found: ${clusters.length}`);
+  console.log(`PRs in clusters: ${totalDuplicatePRs}`);
+  console.log(`Estimated unique PRs: ~${uniquePRs}`);
+  console.log('');
+
+  if (patchClusters.length > 0) {
+    console.log('!!! DUPLICATE PATCHES FOUND !!!');
+    console.log(`${patchClusters.length} cluster(s) contain multiple of our 90 patches:`);
+    for (const pc of patchClusters) {
+      console.log(`\n  Cluster ${pc.clusterId} (similarity: ${pc.similarity.toFixed(2)}):`);
+      for (const p of pc.patchedPRs) {
+        console.log(`    #${p.number} (score: ${p.score}) — ${p.title}`);
+      }
+      console.log(`    Best PR: #${pc.bestPR}`);
+    }
+  } else {
+    console.log('No duplicate patches found in our 90 patches.');
+  }
+
+  console.log('');
+  console.log('Largest clusters:');
+  result.clustersBySize.slice(0, 15).forEach(c => {
+    const patchMark = c.prs.some((p: any) => p.isPatched) ? ' [HAS PATCH]' : '';
+    console.log(`  Cluster ${c.id}: ${c.size} PRs, sim=${c.similarity.toFixed(2)}${patchMark}`);
+    c.prs.forEach((p: any) => {
+      const mark = p.isPatched ? ' ***PATCHED***' : '';
+      console.log(`    #${p.number} (${p.score}) ${p.title}${mark}`);
+    });
+  });
+
+  console.log('');
+  console.log('Score distribution after dedup:');
+  for (const [k, v] of Object.entries(result.scoreDistAfterDedup.distribution)) {
+    console.log(`  ${k}: ${v}`);
+  }
+  console.log(`  Total unique: ${result.scoreDistAfterDedup.total}`);
+
+  console.log(`\nFull results: ${OUTPUT}`);
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/docs/plans/2026-02-24-scoring-v2-enhancements-design.md
+++ b/docs/plans/2026-02-24-scoring-v2-enhancements-design.md
@@ -1,0 +1,84 @@
+# Scoring v2 Enhancements — Evidence-Based Design
+
+## Problem
+v0.8.0 dual scoring (ideaScore + readinessScore) has score compression:
+- Haiku 4.5: ideaScore stddev 9.2, range 35-88
+- Sonnet 4.6: ideaScore stddev 13.7, range 18-88
+- readinessScore max 71 (dataset-specific, not a bug)
+
+## Evidence-Based Solutions
+
+### 1. CheckEval — Binary Checklist Decomposition
+
+**Source:** CheckEval (EMNLP 2025), "Rubric Is All You Need" (ACM ICER 2025)
+
+Replace single 0-100 LLM score with 15 yes/no questions.
+`ideaScore = (yes_count / 15) * 100`
+
+**Why it works:** Binary decisions are far more reliable than numeric judgments (Pearson 0.912 vs 0.745). Mechanically eliminates score compression — LLM never picks a number.
+
+**Questions (15):**
+1. Does this fix a bug that users have reported or would encounter?
+2. Does this address a security vulnerability?
+3. Does this fix a crash, data loss, or data corruption scenario?
+4. Does this solve a performance problem?
+5. Does this add a new user-facing capability?
+6. Does this improve developer experience (DX, tooling, workflow)?
+7. Does the problem affect multiple users or use cases (broad impact)?
+8. Is the technical approach sound and well-reasoned?
+9. Does this remove meaningful technical debt?
+10. Is this a novel/non-obvious solution (not just a trivial fix)?
+11. Would you want this change in your own codebase?
+12. Does this address a documented issue or known pain point?
+13. Does the approach align with the project's architecture?
+14. Could this benefit other projects beyond the immediate scope?
+15. Is the problem important for the project's long-term health?
+
+**Score granularity:** 16 possible values (0, 6.7, 13.3, ..., 93.3, 100)
+
+### 2. Weighted Geometric Mean
+
+**Source:** Triantaphyllou (2001), PMC 729-scenario simulation
+
+Replace `0.7*idea + 0.3*readiness` with:
+```
+floor = 5
+totalScore = max(floor, ideaScore)^0.65 * max(floor, readinessScore)^0.35
+```
+
+**Why:** Heterojen sources (LLM vs TOPSIS), rank reversal immune, zero-veto with floor.
+
+**Examples:**
+| idea | readiness | Additive | Geometric |
+|------|-----------|----------|-----------|
+| 93   | 20        | 71       | 56        |
+| 93   | 93        | 93       | 93        |
+| 47   | 47        | 47       | 47        |
+| 27   | 80        | 43       | 39        |
+| 87   | 67        | 81       | 80        |
+| 0    | 80        | 24       | 8 (floor) |
+
+### 3. Few-Shot Anchor Examples
+
+**Source:** Zhao et al. (ICML 2021), GoDaddy production
+
+Add 5 calibration anchors to the checklist prompt showing expected answers for extreme cases. Breaks central tendency by demonstrating the full range.
+
+## What We Excluded (and why)
+
+| Technique | Reason for exclusion |
+|-----------|---------------------|
+| RRF | Designed for 5+ rankers; loses score magnitude with 2 sources (Shen et al. 2023) |
+| Confidence-Weighted Fusion | LLM self-confidence uncalibrated, ECE 0.108-0.427 (Yang et al. 2024) |
+| Domain Multipliers | INTENT_PROFILES already covers this; no evidence for additional static multipliers |
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `scoring.ts` | CheckEval prompt, geometric mean, few-shot anchors |
+| `types.ts` | `ideaChecklist?: boolean[]` field |
+| `scoring.test.ts` | Updated tests |
+| `scoring-engine.test.ts` | Integration test updates |
+| `pr-factory.ts` | New defaults |
+| `CHANGELOG.md` | Update v0.8.0 entry |

--- a/marketing/reddit-posts.md
+++ b/marketing/reddit-posts.md
@@ -1,0 +1,51 @@
+# Reddit Campaign — Treliq v0.5.1
+
+## r/opensource
+
+Built a new release of **Treliq** (OSS) for PR triage: rank and prioritize open PRs using 20 signals + optional LLM scoring.
+
+v0.5.1 adds:
+- Scope Coherence signal (detect scattered PRs)
+- PR Complexity signal (size/overengineering awareness)
+- OpenRouter provider support
+- `--model` flag for per-run model control
+- Embedding auto-fallback (Anthropic/OpenRouter workflows)
+
+Repo: https://github.com/mahsumaktas/treliq
+Release: https://github.com/mahsumaktas/treliq/releases/tag/v0.5.1
+
+Happy to hear what signals are missing for real maintainer workflows.
+
+---
+
+## r/github
+
+If you maintain repos with many incoming PRs, I just shipped Treliq v0.5.1.
+
+It’s a triage layer (not another reviewer):
+- scores PRs,
+- finds likely duplicates,
+- surfaces risky/overengineered/scattered PRs faster.
+
+New in v0.5.1:
+- 20-signal scoring
+- Scope Coherence + Complexity signals
+- OpenRouter support
+- `--model` CLI option
+
+Repo: https://github.com/mahsumaktas/treliq
+
+---
+
+## r/programming (short)
+
+Shipped **Treliq v0.5.1** — open-source PR triage tool.
+
+New bits:
+- 20-signal ranking
+- Scope coherence detection
+- Complexity/overengineering detection
+- OpenRouter + model selection (`--model`)
+
+If you review lots of OSS PRs, I’d love your feedback.
+https://github.com/mahsumaktas/treliq

--- a/marketing/show-hn.md
+++ b/marketing/show-hn.md
@@ -1,0 +1,31 @@
+# Show HN: Treliq v0.5.1 — PR triage with 20 signals, OpenRouter, and model control
+
+Hey HN — I built **Treliq**, a CLI + dashboard for open-source maintainers to decide *which PR to review/merge first*.
+
+v0.5.1 just shipped with:
+- **20-signal scoring** (new: Scope Coherence + PR Complexity)
+- **`--model` flag** (choose model per run)
+- **OpenRouter provider** support
+- **Embedding auto-fallback** (Anthropic/OpenRouter → Gemini/OpenAI)
+
+Why this exists: code review tools are good at reviewing code, but maintainers still ask:
+- Which PR is highest value?
+- Which one is overengineered or scattered?
+- Which PRs are duplicates?
+
+Treliq focuses on triage/ranking, not replacing review.
+
+Install:
+```bash
+npm i -g treliq
+```
+
+Try:
+```bash
+treliq scan -r owner/repo --provider openrouter --model anthropic/claude-sonnet-4.5
+```
+
+Repo: https://github.com/mahsumaktas/treliq
+Release: https://github.com/mahsumaktas/treliq/releases/tag/v0.5.1
+
+Would love feedback from maintainers managing large PR queues.

--- a/marketing/twitter-thread.md
+++ b/marketing/twitter-thread.md
@@ -1,0 +1,28 @@
+# X Thread — Treliq v0.5.1
+
+1/ Shipped **Treliq v0.5.1** 🚀
+A PR triage tool for OSS maintainers (CLI + dashboard).
+
+Release: https://github.com/mahsumaktas/treliq/releases/tag/v0.5.1
+
+2/ What’s new:
+✅ 20-signal scoring
+✅ Scope Coherence signal
+✅ PR Complexity signal
+✅ OpenRouter provider
+✅ `--model` flag
+✅ Embedding auto-fallback
+
+3/ Why this matters:
+Code review tools answer “is this code okay?”
+Maintainers still need “which PR should I merge first?”
+Treliq focuses on that ranking/triage gap.
+
+4/ Example:
+```bash
+treliq scan -r owner/repo --provider openrouter --model anthropic/claude-sonnet-4.5
+```
+
+5/ Open source + feedback welcome 🙌
+Repo: https://github.com/mahsumaktas/treliq
+If you maintain large PR queues, tell me which triage signals you want next.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "treliq",
-  "version": "0.5.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "treliq",
-      "version": "0.5.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^11.2.0",
@@ -39,6 +39,7 @@
         "jest": "^29.0.0",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.7.0",
         "typescript-eslint": "^8.56.0"
       },
@@ -564,6 +565,448 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3939,6 +4382,48 @@
         "is-arrayish": "^0.2.1"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -4678,6 +5163,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.13.6",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
+      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/github-from-package": {
@@ -6756,6 +7254,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -7453,6 +7961,26 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD",
       "peer": true
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "treliq",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "AI-Powered PR Triage for Open Source Maintainers",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "jest": "^29.0.0",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.0",
+    "tsx": "^4.21.0",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.56.0"
   }

--- a/src/core/graphql.ts
+++ b/src/core/graphql.ts
@@ -129,10 +129,12 @@ export const SINGLE_PR_QUERY = `
         changedFiles
         milestone { title }
         labels(first: 50) { nodes { name } }
-        requestedReviewers(first: 20) {
+        reviewRequests(first: 20) {
           nodes {
-            ... on User { login }
-            ... on Team { name }
+            requestedReviewer {
+              ... on User { login }
+              ... on Team { name }
+            }
           }
         }
         reviews(last: 50) {

--- a/src/core/scanner.ts
+++ b/src/core/scanner.ts
@@ -156,7 +156,24 @@ export class TreliqScanner {
       },
     }) : undefined;
     this.wrappedProvider = wrappedProvider;
-    this.scoring = new ScoringEngine(wrappedProvider, config.trustContributors, 5);
+    if (config.cascade?.enabled && config.cascade.reScoreProvider) {
+      const wrappedReScore = new RetryableProvider(config.cascade.reScoreProvider, {
+        onThrottle: () => { this.scoring.throttle(); },
+      });
+      this.scoring = new ScoringEngine({
+        provider: wrappedProvider,
+        trustContributors: config.trustContributors,
+        maxConcurrent: 5,
+        cascade: {
+          enabled: true,
+          reScoreProvider: wrappedReScore,
+          preFilterThreshold: config.cascade.preFilterThreshold,
+          haikuThreshold: config.cascade.haikuThreshold,
+        },
+      });
+    } else {
+      this.scoring = new ScoringEngine(wrappedProvider, config.trustContributors, 5);
+    }
     if (config.dbPath) {
       this.db = new TreliqDB(config.dbPath);
     }

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -286,8 +286,11 @@ export class ScoringEngine {
     const prompt = `Evaluate the IDEA VALUE of this PR by answering each question with true or false.
 Score the IDEA and the problem it solves, NOT the PR quality or polish.
 
-IMPORTANT: Diff size does NOT determine value. A 4-line fix preventing crashes for all users
-is MORE valuable than a 500-line cosmetic refactor. Judge the PROBLEM being solved.
+IMPORTANT:
+- Diff size does NOT determine value. A 4-line fix preventing crashes is MORE valuable than a 500-line cosmetic refactor.
+- Do NOT trust the PR title at face value. A PR titled "feat(security)" that only adds unintegrated utility functions has less value than a simple null-check that prevents real crashes.
+- Code that is NOT wired into the running system yet (standalone utilities, helpers not called anywhere) has potential but NOT immediate value — answer Q10, Q11, Q14 as false for unintegrated code.
+- Config/default changes that affect ALL installations or users count as broad impact for Q7.
 
 Questions:
 1. Does this fix a bug that users have reported or would encounter in normal usage?
@@ -309,9 +312,10 @@ Questions:
 Calibration anchors:
 - Security fix adding timingSafeEqual to prevent timing attacks (3 lines changed): [true,true,false,false,false,false,true,true,false,true,true,true,true,true,true] = 10/15
 - Fix for null/undefined crash in UI filter affecting all users (8 lines): [true,false,true,false,false,false,true,true,false,true,true,true,true,true,true] = 10/15
+- Standalone utility functions not wired into any running code yet ("feat(security)" label but no integration): [false,false,false,false,true,false,false,true,false,false,false,false,true,false,false] = 3/15
 - Typo fix in README: [false,false,false,false,false,false,false,true,false,false,false,false,true,false,false] = 2/15
 - Spam/empty PR with no real changes: [false,false,false,false,false,false,false,false,false,false,false,false,false,false,false] = 0/15
-- New API endpoint for user dashboard: [false,false,false,false,true,true,true,true,false,false,true,true,true,false,true] = 8/15
+- Config default changes affecting all users (token optimization, memory settings): [false,false,false,true,false,false,true,true,false,false,true,false,true,false,true] = 6/15
 
 Return JSON: {"answers": [true/false for each of the 15 questions], "risk": "low"|"medium"|"high", "reason": "<1 sentence>"}
 

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -48,6 +48,17 @@ const INTENT_PROFILES: Record<IntentCategory, Partial<Record<string, number>>> =
 
 const log = createLogger('scoring');
 
+/** Result from dual CheckEval scoring */
+interface LLMScoringResult {
+  ideaScore: number;
+  implementationScore: number;
+  risk: 'low' | 'medium' | 'high';
+  reason: string;
+  ideaChecklist: boolean[];
+  implementationChecklist: boolean[];
+  checklist: boolean[];  // combined for backward compat
+}
+
 export class ScoringEngine {
   private provider?: LLMProvider;
   private trustContributors: boolean;
@@ -179,19 +190,23 @@ export class ScoringEngine {
     if (isAbandoned) penaltyMultiplier *= 0.3;
     const readinessScore = Math.round(Math.max(0, Math.min(100, topsisScore * penaltyMultiplier)));
 
-    // 7. LLM idea scoring (CheckEval binary checklist)
+    // 7. LLM dual scoring (CheckEval: idea + implementation)
     let ideaScore: number | undefined;
     let ideaReason: string | undefined;
-    let llmRisk: 'low' | 'medium' | 'high' | undefined;
     let ideaChecklist: boolean[] | undefined;
+    let implementationScore: number | undefined;
+    let implementationChecklist: boolean[] | undefined;
+    let llmRisk: 'low' | 'medium' | 'high' | undefined;
 
     if (this.provider) {
       try {
         const llmResult = await this.scoreLLM(pr);
-        ideaScore = llmResult.score;
+        ideaScore = llmResult.ideaScore;
+        implementationScore = llmResult.implementationScore;
         ideaReason = llmResult.reason;
         llmRisk = llmResult.risk;
-        ideaChecklist = llmResult.checklist;
+        ideaChecklist = llmResult.ideaChecklist;
+        implementationChecklist = llmResult.implementationChecklist;
       } catch (err: any) {
         ideaReason = `LLM failed: ${err.message}`;
         log.warn({ pr: pr.number, err }, 'LLM scoring failed');
@@ -200,26 +215,24 @@ export class ScoringEngine {
 
     // 8. Diff analysis bonus (if available)
     const diffAnalysis = this.diffAnalyses.get(pr.number);
-    if (diffAnalysis && ideaScore !== undefined) {
-      ideaScore = Math.round(0.6 * ideaScore + 0.4 * diffAnalysis.codeQuality);
+    if (diffAnalysis && implementationScore !== undefined) {
+      implementationScore = Math.round(0.6 * implementationScore + 0.4 * diffAnalysis.codeQuality);
       if (diffAnalysis.riskAssessment !== 'medium') {
         llmRisk = diffAnalysis.riskAssessment === 'critical' ? 'high' : diffAnalysis.riskAssessment;
       }
     }
 
-    // 9. Combined total score — weighted geometric mean (Triantaphyllou 2001, PMC 729-scenario)
-    // Geometric mean penalizes low readiness more aggressively than additive
+    // 9. Combined total score: idea-heavy weighted average
     let totalScore: number;
-    if (ideaScore !== undefined) {
-      const FLOOR = 5; // prevent zero-veto from completely zeroing out
-      const safeIdea = Math.max(FLOOR, ideaScore);
-      const safeReadiness = Math.max(FLOOR, readinessScore);
-      totalScore = Math.round(Math.pow(safeIdea, 0.65) * Math.pow(safeReadiness, 0.35));
+    if (ideaScore !== undefined && implementationScore !== undefined) {
+      totalScore = Math.round(0.7 * ideaScore + 0.3 * implementationScore);
+    } else if (ideaScore !== undefined) {
+      totalScore = ideaScore;
     } else {
       totalScore = readinessScore; // no LLM = readiness only
     }
 
-    // 10. Tier classification
+    // 10. Tier classification (based on ideaScore)
     const tier = this.assignTier(ideaScore ?? readinessScore, readinessScore);
 
     return {
@@ -239,6 +252,9 @@ export class ScoringEngine {
       ideaScore,
       ideaReason,
       ideaChecklist,
+      implementationScore,
+      implementationReason: ideaReason,
+      implementationChecklist,
       readinessScore,
       penaltyMultiplier,
       tier,
@@ -267,24 +283,24 @@ export class ScoringEngine {
     return (dMinus / (dPlus + dMinus)) * 100;
   }
 
-  /** Assign priority tier based on ideaScore + readinessScore */
-  private assignTier(ideaScore: number, readinessScore: number): 'critical' | 'high' | 'normal' | 'low' {
-    if (ideaScore >= 80 && readinessScore >= 55) return 'critical';
-    if (ideaScore >= 67) return 'high';
-    if (ideaScore >= 40) return 'normal';
+  /** Assign priority tier based primarily on ideaScore */
+  private assignTier(ideaScore: number, _readinessScore: number): 'critical' | 'high' | 'normal' | 'low' {
+    if (ideaScore >= 80) return 'critical';
+    if (ideaScore >= 60) return 'high';
+    if (ideaScore >= 30) return 'normal';
     return 'low';
   }
 
   /**
    * CheckEval — Binary Checklist Decomposition (EMNLP 2025)
-   * 15 yes/no questions instead of single 0-100 score.
-   * ideaScore = (yes_count / 15) * 100
-   * Evidence: inter-evaluator agreement +0.45, Pearson 0.912 vs 0.745 for numeric scales.
+   * Split into two checklists: 10 idea questions + 5 implementation questions.
+   * ideaScore = (idea_yes / 10) * 100
+   * implementationScore = (impl_yes / 5) * 100
    *
    * Multi-pass self-consistency (Wang et al. 2023): when scoringPasses > 1,
    * runs N times with varied temperature and takes median by yesCount.
    */
-  private async scoreLLM(pr: PRData): Promise<{ score: number; risk: 'low' | 'medium' | 'high'; reason: string; checklist?: boolean[] }> {
+  private async scoreLLM(pr: PRData): Promise<LLMScoringResult> {
     if (this.scoringPasses <= 1) {
       return this.scoreLLMSingle(pr, 0.1);
     }
@@ -293,81 +309,101 @@ export class ScoringEngine {
     const results = await Promise.all(
       Array.from({ length: this.scoringPasses }, () => this.scoreLLMSingle(pr, 0.4))
     );
-    results.sort((a, b) => a.score - b.score);
+    results.sort((a, b) => a.ideaScore - b.ideaScore);
     return results[Math.floor(results.length / 2)];
   }
 
-  private async scoreLLMSingle(pr: PRData, temperature: number): Promise<{ score: number; risk: 'low' | 'medium' | 'high'; reason: string; checklist?: boolean[] }> {
+  private async scoreLLMSingle(pr: PRData, temperature: number): Promise<LLMScoringResult> {
     const filesStr = pr.changedFiles.slice(0, 30).join(', ');
     const input = `Title: ${pr.title}\nBody: ${(pr.body ?? '').slice(0, 2000)}\nFiles: ${filesStr}`.slice(0, 4000);
     const issueCtx = pr.issueContext ? `\nLinked issue:\n${pr.issueContext.slice(0, 1000)}\n` : '';
 
-    const prompt = `Evaluate the IDEA VALUE of this PR by answering each question with true or false.
-Score the IDEA and the problem it solves, NOT the PR quality or polish.
+    const prompt = `Evaluate this PR on two dimensions by answering each question true or false.
+
+PART A — IDEA VALUE: How valuable is the PROBLEM this PR identifies and the APPROACH it proposes?
+Score the idea, not the code. A brilliant idea with terrible code still has high idea value.
 
 IMPORTANT:
 - Diff size does NOT determine value. A 4-line fix preventing crashes is MORE valuable than a 500-line cosmetic refactor.
-- Do NOT trust the PR title at face value. A PR titled "feat(security)" that only adds unintegrated utility functions has less value than a simple null-check that prevents real crashes.
-- Code that is NOT wired into the running system yet (standalone utilities, helpers not called anywhere) has potential but NOT immediate value — answer Q10, Q11, Q14 as false for unintegrated code.
-- Config/default changes that affect ALL installations or users count as broad impact for Q7.
-- Community contributions (new plugins, skills, integrations, documentation for ecosystem) have value — answer Q5 as true.
-- Security vulnerability fixes (prototype pollution, injection, auth bypass) protect ALL users even if unexploited — they deserve high scores.
+- Security vulnerability fixes (prototype pollution, injection, auth bypass) protect ALL users even if unexploited — high idea value.
+- "Silent" problems (memory leaks, credential exposure, data corruption) that cause harm without obvious symptoms are especially valuable to identify.
+- Config/default changes that affect ALL installations count as broad impact.
+- Community contributions (plugins, skills, integrations, ecosystem docs) have value.
 - Documentation that only promotes the author's own unrelated external project is self-promotion, not a contribution.
 
-Questions:
-1. Does this fix a bug that users have reported or would encounter in normal usage?
-2. Does this address a security vulnerability, hardening need, or defense-in-depth concern (timing attack, injection, auth bypass, access control, secret exposure, path traversal, XSS, or similar)?
-3. Does this fix a crash, service failure, or error scenario (null/undefined errors, uncaught exceptions, blank screens, broken workflows, unhandled edge cases)?
-4. Does this solve a performance problem (latency, memory, CPU, resource leaks)?
-5. Does this add a meaningful new capability, configuration option, integration, or community contribution?
-6. Does this improve developer experience (DX, tooling, debugging, deployment)?
-7. Does the problem affect multiple users, environments, or use cases (broad impact)?
-8. Is the technical approach sound and well-reasoned for the problem at hand?
-9. Does this remove meaningful technical debt or improve maintainability?
-10. Would leaving this unfixed cause real harm, breakage, or security risk?
-11. Would you want this change in your own production codebase?
-12. Does this address a documented issue, known pain point, or recurring problem?
-13. Does the approach align with the project's architecture and conventions?
-14. Does this prevent a failure mode that could affect production stability or data integrity?
-15. Is the problem important for the project's long-term health and reliability?
+Idea Questions:
+I1. Does this identify a real problem that users or developers actually encounter?
+I2. Does this address a security vulnerability, hardening need, or defense-in-depth concern?
+I3. Does this address a crash, data loss, or service outage scenario?
+I4. Does this solve a performance, reliability, or resource efficiency problem?
+I5. Does this propose a meaningful new capability, configuration option, or integration?
+I6. Does the identified problem affect a broad base of users or installations?
+I7. Is this a "silent" problem — causing harm without obvious symptoms until too late?
+I8. Is the proposed approach/solution technically sound for the problem?
+I9. Does this represent a non-obvious insight or valuable problem identification?
+I10. Would you want this problem fixed in your codebase, regardless of who writes the fix?
 
-Calibration anchors:
-- Security fix adding timingSafeEqual to prevent timing attacks (3 lines changed): [true,true,false,false,false,false,true,true,false,true,true,true,true,true,true] = 10/15
-- Fix for null/undefined crash in UI filter affecting all users (8 lines): [true,false,true,false,false,false,true,true,false,true,true,true,true,true,true] = 10/15
-- Standalone utility functions not wired into any running code yet ("feat(security)" label but no integration): [false,false,false,false,true,false,false,true,false,false,false,false,true,false,false] = 3/15
-- Typo fix in README: [false,false,false,false,false,false,false,true,false,false,false,false,true,false,false] = 2/15
-- Spam/empty PR with no real changes: [false,false,false,false,false,false,false,false,false,false,false,false,false,false,false] = 0/15
-- Config default changes affecting all users (token optimization, memory settings): [false,false,false,true,false,false,true,true,false,false,true,false,true,false,true] = 6/15
-- Community plugin documentation (new ecosystem skill/plugin page): [false,false,false,false,true,false,false,true,false,false,false,false,true,false,true] = 4/15
-- Security config option for network access control (e.g., strictLoopback): [false,true,false,false,true,false,true,true,false,true,true,false,true,false,true] = 8/15
-- Proactive security hardening (TLS warnings, auth validation, defense-in-depth): [false,true,false,false,false,false,true,true,false,true,true,true,true,true,true] = 9/15
-- Critical security vulnerability fix blocking prototype pollution / injection in template resolver: [false,true,false,false,false,false,true,true,true,true,true,true,true,true,true] = 10/15
-- Crash prevention: catching unhandled I/O write failures that crash the gateway process: [true,false,true,false,false,false,true,true,false,true,true,true,true,true,true] = 10/15
-- Self-promotional documentation page for author's own unrelated external npm package (not integrated with the project): [false,false,false,false,false,false,false,false,false,false,false,false,false,false,false] = 0/15
-- Small focused UX fix: removing stale UI reaction emoji after bot reply in Slack (real reproducible bug, clean fix): [true,false,false,false,false,false,false,true,false,false,true,true,true,false,true] = 6/15
+PART B — IMPLEMENTATION QUALITY: How well is this PR actually implemented?
+Score the code, not the idea. Good code for a bad idea still has high implementation quality.
 
-Return JSON: {"answers": [true/false for each of the 15 questions], "risk": "low"|"medium"|"high", "reason": "<1 sentence>"}
+Implementation Questions:
+M1. Is the code integrated into the running system (not standalone/dead code)?
+M2. Does the implementation correctly and completely solve the identified problem?
+M3. Are there meaningful tests that verify the fix works?
+M4. Is the code clean, handling edge cases, without introducing new issues?
+M5. Could this be merged as-is without requiring significant rework?
+
+Calibration anchors (idea / implementation):
+- Security fix timingSafeEqual (3 lines, integrated): idea=[t,t,f,f,f,t,t,t,t,t]=7/10, impl=[t,t,t,t,t]=5/5
+- Null crash fix in UI filter (8 lines, integrated): idea=[t,f,t,f,f,t,f,t,f,t]=5/10, impl=[t,t,t,t,t]=5/5
+- 3 standalone safety utilities NOT wired in (transcript purge, tool budget, token reuse): idea=[t,t,f,f,t,t,t,t,t,t]=8/10, impl=[f,f,t,t,f]=2/5
+- Typo fix in README: idea=[f,f,f,f,f,f,f,f,f,f]=0/10, impl=[t,t,f,t,t]=4/5
+- Spam/empty PR: idea=[f,f,f,f,f,f,f,f,f,f]=0/10, impl=[f,f,f,f,f]=0/5
+- Config defaults affecting all users: idea=[t,f,f,t,t,t,f,t,f,t]=6/10, impl=[t,t,f,t,t]=4/5
+- Community plugin docs (ecosystem page): idea=[f,f,f,f,t,f,f,f,f,f]=1/10, impl=[t,t,f,t,t]=4/5
+- Self-promotional docs (author's own unrelated package): idea=[f,f,f,f,f,f,f,f,f,f]=0/10, impl=[f,f,f,f,f]=0/5
+- Proactive security hardening (TLS, auth, defense-in-depth): idea=[t,t,f,f,f,t,t,t,t,t]=7/10, impl=[t,t,t,t,t]=5/5
+- Critical prototype pollution fix: idea=[t,t,f,f,f,t,t,t,t,t]=7/10, impl=[t,t,t,t,t]=5/5
+- Crash prevention (catching unhandled I/O failures): idea=[t,f,t,f,f,t,t,t,f,t]=6/10, impl=[t,t,t,t,t]=5/5
+- Small UX fix (Slack reaction emoji, real bug): idea=[t,f,f,f,f,f,f,t,f,t]=3/10, impl=[t,t,f,t,t]=4/5
+
+Return JSON: {"idea": [true/false x10], "implementation": [true/false x5], "risk": "low"|"medium"|"high", "reason": "<1 sentence: what problem does this identify?>"}
 ${issueCtx}
 ${input}`;
 
-    const text = await this.provider!.generateText(prompt, { temperature, maxTokens: 300 });
+    const text = await this.provider!.generateText(prompt, { temperature, maxTokens: 400 });
 
     const match = text.match(/\{[\s\S]*\}/);
     if (!match) throw new Error('No JSON found in LLM response');
     try {
       const parsed = JSON.parse(match[0]);
-      const answers: boolean[] = Array.isArray(parsed.answers)
-        ? parsed.answers.slice(0, 15).map((a: unknown) => Boolean(a))
+
+      // Parse idea answers (10 questions)
+      const ideaAnswers: boolean[] = Array.isArray(parsed.idea)
+        ? parsed.idea.slice(0, 10).map((a: unknown) => Boolean(a))
         : [];
-      // Pad to 15 if LLM returned fewer
-      while (answers.length < 15) answers.push(false);
-      const yesCount = answers.filter(a => a).length;
-      const score = Math.round((yesCount / 15) * 100);
+      while (ideaAnswers.length < 10) ideaAnswers.push(false);
+
+      // Parse implementation answers (5 questions)
+      const implAnswers: boolean[] = Array.isArray(parsed.implementation)
+        ? parsed.implementation.slice(0, 5).map((a: unknown) => Boolean(a))
+        : [];
+      while (implAnswers.length < 5) implAnswers.push(false);
+
+      // Backward compat: combined checklist
+      const combinedChecklist = [...ideaAnswers, ...implAnswers];
+
+      const ideaYes = ideaAnswers.filter(a => a).length;
+      const implYes = implAnswers.filter(a => a).length;
+
       return {
-        score,
+        ideaScore: Math.round((ideaYes / 10) * 100),
+        implementationScore: Math.round((implYes / 5) * 100),
         risk: ['low', 'medium', 'high'].includes(parsed.risk) ? parsed.risk : 'medium',
         reason: String(parsed.reason ?? ''),
-        checklist: answers,
+        ideaChecklist: ideaAnswers,
+        implementationChecklist: implAnswers,
+        checklist: combinedChecklist,
       };
     } catch (parseErr: any) {
       throw new Error(`JSON parse failed: ${parseErr.message}`);

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -2,7 +2,7 @@
  * ScoringEngine — Multi-signal PR scoring with LLM-assisted analysis
  */
 
-import type { PRData, ScoredPR, SignalScore, DiffAnalysis } from './types';
+import type { PRData, ScoredPR, SignalScore, DiffAnalysis, ScoringEngineOptions } from './types';
 import type { LLMProvider } from './provider';
 import { IntentClassifier, type IntentResult } from './intent';
 import { ConcurrencyController } from './concurrency';
@@ -52,6 +52,7 @@ const log = createLogger('scoring');
 interface LLMScoringResult {
   ideaScore: number;
   implementationScore: number;
+  noveltyBonus: number;
   risk: 'low' | 'medium' | 'high';
   reason: string;
   ideaChecklist: boolean[];
@@ -67,13 +68,38 @@ export class ScoringEngine {
   private intentClassifier: IntentClassifier;
   private diffAnalyses = new Map<number, DiffAnalysis>();
   private scoringPasses: number;
+  private reScoreProvider?: LLMProvider;
+  private cascadeEnabled: boolean = false;
+  private preFilterThreshold: number = 15;
+  private haikuThreshold: number = 40;
 
-  constructor(provider?: LLMProvider, trustContributors = false, maxConcurrent = 5, scoringPasses = 1) {
-    this.provider = provider;
-    this.trustContributors = trustContributors;
-    this.concurrency = new ConcurrencyController(maxConcurrent);
-    this.intentClassifier = new IntentClassifier(provider);
-    this.scoringPasses = Math.max(1, scoringPasses);
+  constructor(provider?: LLMProvider, trustContributors?: boolean, maxConcurrent?: number, scoringPasses?: number);
+  constructor(options: ScoringEngineOptions);
+  constructor(
+    providerOrOptions?: LLMProvider | ScoringEngineOptions,
+    trustContributors = false,
+    maxConcurrent = 5,
+    scoringPasses = 1,
+  ) {
+    // Detection: LLMProvider has generateText, ScoringEngineOptions doesn't
+    if (providerOrOptions && typeof providerOrOptions === 'object' && !('generateText' in providerOrOptions)) {
+      const opts = providerOrOptions as ScoringEngineOptions;
+      this.provider = opts.provider;
+      this.trustContributors = opts.trustContributors ?? false;
+      this.concurrency = new ConcurrencyController(opts.maxConcurrent ?? 5);
+      this.scoringPasses = Math.max(1, opts.scoringPasses ?? 1);
+      this.cascadeEnabled = opts.cascade?.enabled ?? false;
+      this.reScoreProvider = opts.cascade?.reScoreProvider;
+      this.preFilterThreshold = opts.cascade?.preFilterThreshold ?? 15;
+      this.haikuThreshold = opts.cascade?.haikuThreshold ?? 40;
+    } else {
+      // Legacy positional — all existing tests use this path
+      this.provider = providerOrOptions as LLMProvider | undefined;
+      this.trustContributors = trustContributors;
+      this.concurrency = new ConcurrencyController(maxConcurrent);
+      this.scoringPasses = Math.max(1, scoringPasses);
+    }
+    this.intentClassifier = new IntentClassifier(this.provider);
   }
 
   /** Halve concurrency on rate-limit (429) */
@@ -190,15 +216,58 @@ export class ScoringEngine {
     if (isAbandoned) penaltyMultiplier *= 0.3;
     const readinessScore = Math.round(Math.max(0, Math.min(100, topsisScore * penaltyMultiplier)));
 
-    // 7. LLM dual scoring (CheckEval: idea + implementation)
+    // 7. LLM dual scoring (CheckEval: idea + implementation) — with cascade support
     let ideaScore: number | undefined;
     let ideaReason: string | undefined;
     let ideaChecklist: boolean[] | undefined;
     let implementationScore: number | undefined;
     let implementationChecklist: boolean[] | undefined;
     let llmRisk: 'low' | 'medium' | 'high' | undefined;
+    let scoredBy: 'heuristic' | 'haiku' | 'sonnet' | undefined;
+    let noveltyBonusVal: number | undefined;
 
-    if (this.provider) {
+    if (this.cascadeEnabled && this.provider) {
+      // CASCADE PIPELINE
+      if (readinessScore < this.preFilterThreshold || isSpam) {
+        // Stage 1: Pre-filter — skip LLM entirely
+        scoredBy = 'heuristic';
+      } else {
+        // Stage 2: Haiku pass
+        try {
+          const haikuResult = await this.scoreLLM(pr);
+          ideaScore = haikuResult.ideaScore;
+          implementationScore = haikuResult.implementationScore;
+          ideaReason = haikuResult.reason;
+          llmRisk = haikuResult.risk;
+          ideaChecklist = haikuResult.ideaChecklist;
+          implementationChecklist = haikuResult.implementationChecklist;
+          noveltyBonusVal = haikuResult.noveltyBonus;
+          scoredBy = 'haiku';
+
+          // Stage 3: Sonnet re-score if above threshold
+          if (ideaScore >= this.haikuThreshold && this.reScoreProvider) {
+            try {
+              const sonnetResult = await this.scoreLLM(pr, this.reScoreProvider);
+              ideaScore = sonnetResult.ideaScore;
+              implementationScore = sonnetResult.implementationScore;
+              ideaReason = sonnetResult.reason;
+              llmRisk = sonnetResult.risk;
+              ideaChecklist = sonnetResult.ideaChecklist;
+              implementationChecklist = sonnetResult.implementationChecklist;
+              noveltyBonusVal = sonnetResult.noveltyBonus;
+              scoredBy = 'sonnet';
+            } catch (err: any) {
+              log.warn({ pr: pr.number, err }, 'Sonnet re-score failed, keeping Haiku');
+            }
+          }
+        } catch (err: any) {
+          ideaReason = `LLM failed: ${err.message}`;
+          scoredBy = 'heuristic';
+          log.warn({ pr: pr.number, err }, 'Haiku scoring failed');
+        }
+      }
+    } else if (this.provider) {
+      // Legacy non-cascade path
       try {
         const llmResult = await this.scoreLLM(pr);
         ideaScore = llmResult.ideaScore;
@@ -207,6 +276,7 @@ export class ScoringEngine {
         llmRisk = llmResult.risk;
         ideaChecklist = llmResult.ideaChecklist;
         implementationChecklist = llmResult.implementationChecklist;
+        noveltyBonusVal = llmResult.noveltyBonus;
       } catch (err: any) {
         ideaReason = `LLM failed: ${err.message}`;
         log.warn({ pr: pr.number, err }, 'LLM scoring failed');
@@ -235,6 +305,11 @@ export class ScoringEngine {
     // 10. Tier classification (based on ideaScore)
     const tier = this.assignTier(ideaScore ?? readinessScore, readinessScore);
 
+    // 11. readyToSteal: high-value closed/merged PR we can re-implement
+    const readyToSteal = (ideaScore !== undefined && ideaScore >= 70)
+      && (implementationScore !== undefined && implementationScore >= 80)
+      && (pr.state === 'closed' || pr.state === 'merged');
+
     return {
       ...pr,
       totalScore,
@@ -258,6 +333,10 @@ export class ScoringEngine {
       readinessScore,
       penaltyMultiplier,
       tier,
+      // v0.8 cascade
+      scoredBy,
+      readyToSteal: readyToSteal ?? false,
+      noveltyBonus: noveltyBonusVal,
     };
   }
 
@@ -292,28 +371,29 @@ export class ScoringEngine {
   }
 
   /**
-   * CheckEval — Binary Checklist Decomposition (EMNLP 2025)
+   * Hybrid CheckEval — Binary Checklist + Novelty Bonus (EMNLP 2025 + fine-grained)
    * Split into two checklists: 10 idea questions + 5 implementation questions.
-   * ideaScore = (idea_yes / 10) * 100
+   * ideaScore = (idea_yes * 8) + noveltyBonus(0-20)
+   *   → base 0-80 from binary + 0-20 continuous bonus = fine-grained 0-100
    * implementationScore = (impl_yes / 5) * 100
    *
    * Multi-pass self-consistency (Wang et al. 2023): when scoringPasses > 1,
-   * runs N times with varied temperature and takes median by yesCount.
+   * runs N times with varied temperature and takes median by ideaScore.
    */
-  private async scoreLLM(pr: PRData): Promise<LLMScoringResult> {
+  private async scoreLLM(pr: PRData, provider: LLMProvider = this.provider!): Promise<LLMScoringResult> {
     if (this.scoringPasses <= 1) {
-      return this.scoreLLMSingle(pr, 0.1);
+      return this.scoreLLMSingle(pr, 0.1, provider);
     }
 
     // Multi-pass: run N times with slightly higher temperature, take median
     const results = await Promise.all(
-      Array.from({ length: this.scoringPasses }, () => this.scoreLLMSingle(pr, 0.4))
+      Array.from({ length: this.scoringPasses }, () => this.scoreLLMSingle(pr, 0.4, provider))
     );
     results.sort((a, b) => a.ideaScore - b.ideaScore);
     return results[Math.floor(results.length / 2)];
   }
 
-  private async scoreLLMSingle(pr: PRData, temperature: number): Promise<LLMScoringResult> {
+  private async scoreLLMSingle(pr: PRData, temperature: number, provider: LLMProvider = this.provider!): Promise<LLMScoringResult> {
     const filesStr = pr.changedFiles.slice(0, 30).join(', ');
     const input = `Title: ${pr.title}\nBody: ${(pr.body ?? '').slice(0, 2000)}\nFiles: ${filesStr}`.slice(0, 4000);
     const issueCtx = pr.issueContext ? `\nLinked issue:\n${pr.issueContext.slice(0, 1000)}\n` : '';
@@ -353,25 +433,34 @@ M3. Are there meaningful tests that verify the fix works?
 M4. Is the code clean, handling edge cases, without introducing new issues?
 M5. Could this be merged as-is without requiring significant rework?
 
-Calibration anchors (idea / implementation):
-- Security fix timingSafeEqual (3 lines, integrated): idea=[t,t,f,f,f,t,t,t,t,t]=7/10, impl=[t,t,t,t,t]=5/5
-- Null crash fix in UI filter (8 lines, integrated): idea=[t,f,t,f,f,t,f,t,f,t]=5/10, impl=[t,t,t,t,t]=5/5
-- 3 standalone safety utilities NOT wired in (transcript purge, tool budget, token reuse): idea=[t,t,f,f,t,t,t,t,t,t]=8/10, impl=[f,f,t,t,f]=2/5
-- Typo fix in README: idea=[f,f,f,f,f,f,f,f,f,f]=0/10, impl=[t,t,f,t,t]=4/5
-- Spam/empty PR: idea=[f,f,f,f,f,f,f,f,f,f]=0/10, impl=[f,f,f,f,f]=0/5
-- Config defaults affecting all users: idea=[t,f,f,t,t,t,f,t,f,t]=6/10, impl=[t,t,f,t,t]=4/5
-- Community plugin docs (ecosystem page): idea=[f,f,f,f,t,f,f,f,f,f]=1/10, impl=[t,t,f,t,t]=4/5
-- Self-promotional docs (author's own unrelated package): idea=[f,f,f,f,f,f,f,f,f,f]=0/10, impl=[f,f,f,f,f]=0/5
-- Proactive security hardening (TLS, auth, defense-in-depth): idea=[t,t,f,f,f,t,t,t,t,t]=7/10, impl=[t,t,t,t,t]=5/5
-- Critical prototype pollution fix: idea=[t,t,f,f,f,t,t,t,t,t]=7/10, impl=[t,t,t,t,t]=5/5
-- Crash prevention (catching unhandled I/O failures): idea=[t,f,t,f,f,t,t,t,f,t]=6/10, impl=[t,t,t,t,t]=5/5
-- Small UX fix (Slack reaction emoji, real bug): idea=[t,f,f,f,f,f,f,t,f,t]=3/10, impl=[t,t,f,t,t]=4/5
+PART C — NOVELTY & SEVERITY BONUS (0-20):
+Rate the novelty and severity of the problem this PR identifies. This is a fine-grained continuous score to differentiate PRs with similar binary checklist results.
 
-Return JSON: {"idea": [true/false x10], "implementation": [true/false x5], "risk": "low"|"medium"|"high", "reason": "<1 sentence: what problem does this identify?>"}
+0-3:   Routine/trivial (typo, lint, cosmetic)
+4-7:   Standard bug or minor improvement
+8-11:  Valuable problem identification, real user impact
+12-15: Important insight — security, data integrity, or architectural gap
+16-20: Critical/novel discovery — root cause of multiple issues, paradigm shift, or silent production risk
+
+Calibration anchors (idea / implementation / bonus):
+- Security fix timingSafeEqual (3 lines): idea=7/10, impl=5/5, bonus=14
+- Null crash fix in UI filter (8 lines): idea=5/10, impl=5/5, bonus=8
+- Standalone safety utilities NOT wired in (transcript purge, tool budget): idea=8/10, impl=2/5, bonus=12
+- Typo fix in README: idea=0/10, impl=4/5, bonus=0
+- Spam/empty PR: idea=0/10, impl=0/5, bonus=0
+- Config defaults affecting all users: idea=6/10, impl=4/5, bonus=10
+- Community plugin docs (ecosystem page): idea=1/10, impl=4/5, bonus=2
+- Proactive security hardening (TLS, auth, defense-in-depth): idea=7/10, impl=5/5, bonus=15
+- Critical prototype pollution fix: idea=7/10, impl=5/5, bonus=16
+- Crash prevention (catching unhandled I/O failures): idea=6/10, impl=5/5, bonus=13
+- Small UX fix (Slack reaction emoji, real bug): idea=3/10, impl=4/5, bonus=4
+- Root cause fix affecting 10+ upstream issues: idea=8/10, impl=5/5, bonus=19
+
+Return JSON: {"idea": [true/false x10], "implementation": [true/false x5], "noveltyBonus": <0-20 integer>, "risk": "low"|"medium"|"high", "reason": "<1 sentence: what problem does this identify?>"}
 ${issueCtx}
 ${input}`;
 
-    const text = await this.provider!.generateText(prompt, { temperature, maxTokens: 400 });
+    const text = await provider.generateText(prompt, { temperature, maxTokens: 400 });
 
     const match = text.match(/\{[\s\S]*\}/);
     if (!match) throw new Error('No JSON found in LLM response');
@@ -390,15 +479,24 @@ ${input}`;
         : [];
       while (implAnswers.length < 5) implAnswers.push(false);
 
+      // Parse novelty bonus (0-20, clamped)
+      const rawBonus = typeof parsed.noveltyBonus === 'number' ? parsed.noveltyBonus : 0;
+      const noveltyBonus = Math.max(0, Math.min(20, Math.round(rawBonus)));
+
       // Backward compat: combined checklist
       const combinedChecklist = [...ideaAnswers, ...implAnswers];
 
       const ideaYes = ideaAnswers.filter(a => a).length;
       const implYes = implAnswers.filter(a => a).length;
 
+      // Hybrid formula: binary base (0-80) + novelty bonus (0-20) = 0-100
+      const ideaScore = Math.min(100, ideaYes * 8 + noveltyBonus);
+      const implementationScore = Math.round((implYes / 5) * 100);
+
       return {
-        ideaScore: Math.round((ideaYes / 10) * 100),
-        implementationScore: Math.round((implYes / 5) * 100),
+        ideaScore,
+        implementationScore,
+        noveltyBonus,
         risk: ['low', 'medium', 'high'].includes(parsed.risk) ? parsed.risk : 'medium',
         reason: String(parsed.reason ?? ''),
         ideaChecklist: ideaAnswers,

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -267,9 +267,9 @@ export class ScoringEngine {
 
   /** Assign priority tier based on ideaScore + readinessScore */
   private assignTier(ideaScore: number, readinessScore: number): 'critical' | 'high' | 'normal' | 'low' {
-    if (ideaScore >= 80 && readinessScore >= 60) return 'critical';
-    if (ideaScore >= 70) return 'high';
-    if (ideaScore >= 45) return 'normal';
+    if (ideaScore >= 80 && readinessScore >= 55) return 'critical';
+    if (ideaScore >= 67) return 'high';
+    if (ideaScore >= 40) return 'normal';
     return 'low';
   }
 
@@ -286,29 +286,32 @@ export class ScoringEngine {
     const prompt = `Evaluate the IDEA VALUE of this PR by answering each question with true or false.
 Score the IDEA and the problem it solves, NOT the PR quality or polish.
 
+IMPORTANT: Diff size does NOT determine value. A 4-line fix preventing crashes for all users
+is MORE valuable than a 500-line cosmetic refactor. Judge the PROBLEM being solved.
+
 Questions:
-1. Does this fix a bug that users have reported or would encounter?
-2. Does this address a security vulnerability?
-3. Does this fix a crash, data loss, or data corruption scenario?
-4. Does this solve a performance problem?
-5. Does this add a new user-facing capability?
-6. Does this improve developer experience (DX, tooling, workflow)?
-7. Does the problem affect multiple users or use cases (broad impact)?
-8. Is the technical approach sound and well-reasoned?
-9. Does this remove meaningful technical debt?
-10. Is this a novel/non-obvious solution (not just a trivial fix)?
-11. Would you want this change in your own codebase?
-12. Does this address a documented issue or known pain point?
-13. Does the approach align with the project's architecture?
-14. Could this benefit other projects beyond the immediate scope?
-15. Is the problem important for the project's long-term health?
+1. Does this fix a bug that users have reported or would encounter in normal usage?
+2. Does this address a security concern (timing attack, injection, auth bypass, prototype pollution, secret exposure, path traversal, XSS, or similar)?
+3. Does this fix a crash, service failure, or error scenario (null/undefined errors, uncaught exceptions, blank screens, broken workflows, unhandled edge cases)?
+4. Does this solve a performance problem (latency, memory, CPU, resource leaks)?
+5. Does this add a meaningful new user-facing capability or workflow?
+6. Does this improve developer experience (DX, tooling, debugging, deployment)?
+7. Does the problem affect multiple users, environments, or use cases (broad impact)?
+8. Is the technical approach sound and well-reasoned for the problem at hand?
+9. Does this remove meaningful technical debt or improve maintainability?
+10. Would leaving this unfixed cause real harm, breakage, or security risk?
+11. Would you want this change in your own production codebase?
+12. Does this address a documented issue, known pain point, or recurring problem?
+13. Does the approach align with the project's architecture and conventions?
+14. Does this prevent a failure mode that could affect production stability or data integrity?
+15. Is the problem important for the project's long-term health and reliability?
 
 Calibration anchors:
-- Security fix patching CVE in auth module: [true,true,true,false,false,false,true,true,true,true,true,true,true,false,true] = 11/15
+- Security fix adding timingSafeEqual to prevent timing attacks (3 lines changed): [true,true,false,false,false,false,true,true,false,true,true,true,true,true,true] = 10/15
+- Fix for null/undefined crash in UI filter affecting all users (8 lines): [true,false,true,false,false,false,true,true,false,true,true,true,true,true,true] = 10/15
 - Typo fix in README: [false,false,false,false,false,false,false,true,false,false,false,false,true,false,false] = 2/15
-- New API endpoint for user dashboard: [false,false,false,false,true,true,true,true,false,true,true,true,true,true,true] = 10/15
 - Spam/empty PR with no real changes: [false,false,false,false,false,false,false,false,false,false,false,false,false,false,false] = 0/15
-- Routine dependency bump: [false,false,false,false,false,false,false,true,false,false,true,false,true,false,true] = 4/15
+- New API endpoint for user dashboard: [false,false,false,false,true,true,true,true,false,false,true,true,true,false,true] = 8/15
 
 Return JSON: {"answers": [true/false for each of the 15 questions], "risk": "low"|"medium"|"high", "reason": "<1 sentence>"}
 

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -177,10 +177,11 @@ export class ScoringEngine {
     if (isAbandoned) penaltyMultiplier *= 0.3;
     const readinessScore = Math.round(Math.max(0, Math.min(100, topsisScore * penaltyMultiplier)));
 
-    // 7. LLM idea scoring
+    // 7. LLM idea scoring (CheckEval binary checklist)
     let ideaScore: number | undefined;
     let ideaReason: string | undefined;
     let llmRisk: 'low' | 'medium' | 'high' | undefined;
+    let ideaChecklist: boolean[] | undefined;
 
     if (this.provider) {
       try {
@@ -188,6 +189,7 @@ export class ScoringEngine {
         ideaScore = llmResult.score;
         ideaReason = llmResult.reason;
         llmRisk = llmResult.risk;
+        ideaChecklist = llmResult.checklist;
       } catch (err: any) {
         ideaReason = `LLM failed: ${err.message}`;
         log.warn({ pr: pr.number, err }, 'LLM scoring failed');
@@ -203,10 +205,14 @@ export class ScoringEngine {
       }
     }
 
-    // 9. Combined total score
+    // 9. Combined total score — weighted geometric mean (Triantaphyllou 2001, PMC 729-scenario)
+    // Geometric mean penalizes low readiness more aggressively than additive
     let totalScore: number;
     if (ideaScore !== undefined) {
-      totalScore = Math.round(0.7 * ideaScore + 0.3 * readinessScore);
+      const FLOOR = 5; // prevent zero-veto from completely zeroing out
+      const safeIdea = Math.max(FLOOR, ideaScore);
+      const safeReadiness = Math.max(FLOOR, readinessScore);
+      totalScore = Math.round(Math.pow(safeIdea, 0.65) * Math.pow(safeReadiness, 0.35));
     } else {
       totalScore = readinessScore; // no LLM = readiness only
     }
@@ -230,6 +236,7 @@ export class ScoringEngine {
       // v0.8 dual scoring
       ideaScore,
       ideaReason,
+      ideaChecklist,
       readinessScore,
       penaltyMultiplier,
       tier,
@@ -266,42 +273,65 @@ export class ScoringEngine {
     return 'low';
   }
 
-  private async scoreLLM(pr: PRData): Promise<{ score: number; risk: 'low' | 'medium' | 'high'; reason: string }> {
+  /**
+   * CheckEval — Binary Checklist Decomposition (EMNLP 2025)
+   * 15 yes/no questions instead of single 0-100 score.
+   * ideaScore = (yes_count / 15) * 100
+   * Evidence: inter-evaluator agreement +0.45, Pearson 0.912 vs 0.745 for numeric scales.
+   */
+  private async scoreLLM(pr: PRData): Promise<{ score: number; risk: 'low' | 'medium' | 'high'; reason: string; checklist?: boolean[] }> {
     const filesStr = pr.changedFiles.slice(0, 30).join(', ');
     const input = `Title: ${pr.title}\nBody: ${(pr.body ?? '').slice(0, 2000)}\nFiles: ${filesStr}`.slice(0, 4000);
 
-    const prompt = `Evaluate the IDEA VALUE of this PR — how valuable is the problem it solves and the approach it takes? Score the IDEA, not the PR quality.
+    const prompt = `Evaluate the IDEA VALUE of this PR by answering each question with true or false.
+Score the IDEA and the problem it solves, NOT the PR quality or polish.
 
-A brilliant fix with poor tests still has high idea value.
-A polished PR fixing a typo has low idea value.
+Questions:
+1. Does this fix a bug that users have reported or would encounter?
+2. Does this address a security vulnerability?
+3. Does this fix a crash, data loss, or data corruption scenario?
+4. Does this solve a performance problem?
+5. Does this add a new user-facing capability?
+6. Does this improve developer experience (DX, tooling, workflow)?
+7. Does the problem affect multiple users or use cases (broad impact)?
+8. Is the technical approach sound and well-reasoned?
+9. Does this remove meaningful technical debt?
+10. Is this a novel/non-obvious solution (not just a trivial fix)?
+11. Would you want this change in your own codebase?
+12. Does this address a documented issue or known pain point?
+13. Does the approach align with the project's architecture?
+14. Could this benefit other projects beyond the immediate scope?
+15. Is the problem important for the project's long-term health?
 
-Rubric (use the FULL range):
-  90-100: Critical fix for a real production problem (security, data loss, crash)
-  75-89: Valuable improvement solving a genuine pain point
-  50-74: Useful but routine fix or minor enhancement
-  25-49: Low-value change (cosmetic, trivial, or unnecessary)
-  0-24: No practical value (spam, duplicate, or harmful)
+Calibration anchors:
+- Security fix patching CVE in auth module: [true,true,true,false,false,false,true,true,true,true,true,true,true,false,true] = 11/15
+- Typo fix in README: [false,false,false,false,false,false,false,true,false,false,false,false,true,false,false] = 2/15
+- New API endpoint for user dashboard: [false,false,false,false,true,true,true,true,false,true,true,true,true,true,true] = 10/15
+- Spam/empty PR with no real changes: [false,false,false,false,false,false,false,false,false,false,false,false,false,false,false] = 0/15
+- Routine dependency bump: [false,false,false,false,false,false,false,true,false,false,true,false,true,false,true] = 4/15
 
-Consider:
-- Does this solve a REAL problem users/developers face?
-- Is the approach/idea sound (even if implementation is rough)?
-- Would YOU want this change in your codebase?
-- Is this a novel insight or a copy of an obvious pattern?
-
-Return JSON: {"score": <0-100>, "risk": "low"|"medium"|"high", "reason": "<1 sentence: what makes this valuable or not>"}
+Return JSON: {"answers": [true/false for each of the 15 questions], "risk": "low"|"medium"|"high", "reason": "<1 sentence>"}
 
 ${input}`;
 
-    const text = await this.provider!.generateText(prompt, { temperature: 0.1, maxTokens: 200 });
+    const text = await this.provider!.generateText(prompt, { temperature: 0.1, maxTokens: 300 });
 
-    const match = text.match(/\{[^}]+\}/);
+    const match = text.match(/\{[\s\S]*\}/);
     if (!match) throw new Error('No JSON found in LLM response');
     try {
       const parsed = JSON.parse(match[0]);
+      const answers: boolean[] = Array.isArray(parsed.answers)
+        ? parsed.answers.slice(0, 15).map((a: unknown) => Boolean(a))
+        : [];
+      // Pad to 15 if LLM returned fewer
+      while (answers.length < 15) answers.push(false);
+      const yesCount = answers.filter(a => a).length;
+      const score = Math.round((yesCount / 15) * 100);
       return {
-        score: Math.max(0, Math.min(100, Number(parsed.score) || 50)),
+        score,
         risk: ['low', 'medium', 'high'].includes(parsed.risk) ? parsed.risk : 'medium',
         reason: String(parsed.reason ?? ''),
+        checklist: answers,
       };
     } catch (parseErr: any) {
       throw new Error(`JSON parse failed: ${parseErr.message}`);

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -281,8 +281,15 @@ export class ScoringEngine {
     }
     let trustBonus = knownContributor ? -1 : 0;
 
-    if (pr.additions + pr.deletions < 3) { spamScore += 2; reasons.push('<3 lines'); }
-    else if (pr.additions + pr.deletions < 5) { spamScore++; reasons.push('<5 lines'); }
+    // Net-zero detection: code added then reverted
+    const netChange = Math.abs(pr.additions - pr.deletions);
+    const totalLines = pr.additions + pr.deletions;
+    if (totalLines >= 10 && totalLines > 0 && (netChange / totalLines) < 0.05) {
+      spamScore += 3; reasons.push(`Reverted/no-op: +${pr.additions}/-${pr.deletions}`);
+    }
+
+    if (totalLines < 3) { spamScore += 2; reasons.push('<3 lines'); }
+    else if (totalLines < 5) { spamScore++; reasons.push('<5 lines'); }
     if (!pr.hasIssueRef) { spamScore++; reasons.push('No issue ref'); }
     if ((pr.body ?? '').length < 20) { spamScore++; reasons.push('No/short description'); }
     const docsOnly = pr.changedFiles.every(f => /readme|contributing|license|changelog|\.md$|\.txt$/i.test(f));
@@ -325,6 +332,23 @@ export class ScoringEngine {
     else if (days <= 30) { score = 70; label = 'Aging'; }
     else if (days <= 90) { score = 40; label = 'Stale'; }
     else { score = 15; label = 'Very stale'; }
+
+    // Abandoned/incomplete detection: old PR + inactivity signals
+    const titleBody = `${pr.title} ${pr.body ?? ''}`.toLowerCase();
+    const hasWipMarkers = /\bwip\b|\btodo\b|\bfixme\b|\bhack\b|\bwip:/i.test(pr.title) || pr.isDraft;
+    const isAbandoned = days > 180 && pr.commentCount <= 1 && pr.reviewState === 'none';
+
+    if (isAbandoned && hasWipMarkers) {
+      score = 5;
+      label = 'Abandoned+WIP';
+    } else if (isAbandoned) {
+      score = Math.min(score, 10);
+      label = 'Abandoned';
+    } else if (days > 90 && hasWipMarkers) {
+      score = Math.min(score, 10);
+      label = 'Stale+WIP';
+    }
+
     return { name: 'staleness', score, weight: 0.07, reason: `${days}d old (${label})` };
   }
 
@@ -510,11 +534,21 @@ export class ScoringEngine {
     };
   }
 
-  /** Large PR complexity: detect overengineered or massive PRs */
+  /** Large PR complexity: detect overengineered, massive, or reverted PRs */
   private scoreComplexity(pr: PRData): SignalScore {
     const total = pr.additions + pr.deletions;
     const files = pr.changedFiles;
-    if (total === 0) return { name: 'complexity', score: 50, weight: 0.05, reason: 'Empty diff' };
+    if (total === 0) return { name: 'complexity', score: 5, weight: 0.05, reason: 'Empty diff — no actual changes' };
+
+    // Net-zero detection: additions ≈ deletions means code was likely reverted
+    const netChange = Math.abs(pr.additions - pr.deletions);
+    const churn = total > 0 ? netChange / total : 1;
+    if (total >= 10 && churn < 0.05) {
+      return { name: 'complexity', score: 5, weight: 0.05, reason: `Reverted/no-op: +${pr.additions}/-${pr.deletions} (net change ${netChange} lines, ${Math.round(churn * 100)}% effective)` };
+    }
+    if (total >= 20 && churn < 0.15) {
+      return { name: 'complexity', score: 20, weight: 0.05, reason: `Near-reverted: +${pr.additions}/-${pr.deletions} (net ${netChange}, ${Math.round(churn * 100)}% effective)` };
+    }
 
     let score = 80;
     const flags: string[] = [];

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -55,12 +55,14 @@ export class ScoringEngine {
   private concurrency: ConcurrencyController;
   private intentClassifier: IntentClassifier;
   private diffAnalyses = new Map<number, DiffAnalysis>();
+  private scoringPasses: number;
 
-  constructor(provider?: LLMProvider, trustContributors = false, maxConcurrent = 5) {
+  constructor(provider?: LLMProvider, trustContributors = false, maxConcurrent = 5, scoringPasses = 1) {
     this.provider = provider;
     this.trustContributors = trustContributors;
     this.concurrency = new ConcurrencyController(maxConcurrent);
     this.intentClassifier = new IntentClassifier(provider);
+    this.scoringPasses = Math.max(1, scoringPasses);
   }
 
   /** Halve concurrency on rate-limit (429) */
@@ -278,10 +280,27 @@ export class ScoringEngine {
    * 15 yes/no questions instead of single 0-100 score.
    * ideaScore = (yes_count / 15) * 100
    * Evidence: inter-evaluator agreement +0.45, Pearson 0.912 vs 0.745 for numeric scales.
+   *
+   * Multi-pass self-consistency (Wang et al. 2023): when scoringPasses > 1,
+   * runs N times with varied temperature and takes median by yesCount.
    */
   private async scoreLLM(pr: PRData): Promise<{ score: number; risk: 'low' | 'medium' | 'high'; reason: string; checklist?: boolean[] }> {
+    if (this.scoringPasses <= 1) {
+      return this.scoreLLMSingle(pr, 0.1);
+    }
+
+    // Multi-pass: run N times with slightly higher temperature, take median
+    const results = await Promise.all(
+      Array.from({ length: this.scoringPasses }, () => this.scoreLLMSingle(pr, 0.4))
+    );
+    results.sort((a, b) => a.score - b.score);
+    return results[Math.floor(results.length / 2)];
+  }
+
+  private async scoreLLMSingle(pr: PRData, temperature: number): Promise<{ score: number; risk: 'low' | 'medium' | 'high'; reason: string; checklist?: boolean[] }> {
     const filesStr = pr.changedFiles.slice(0, 30).join(', ');
     const input = `Title: ${pr.title}\nBody: ${(pr.body ?? '').slice(0, 2000)}\nFiles: ${filesStr}`.slice(0, 4000);
+    const issueCtx = pr.issueContext ? `\nLinked issue:\n${pr.issueContext.slice(0, 1000)}\n` : '';
 
     const prompt = `Evaluate the IDEA VALUE of this PR by answering each question with true or false.
 Score the IDEA and the problem it solves, NOT the PR quality or polish.
@@ -291,13 +310,16 @@ IMPORTANT:
 - Do NOT trust the PR title at face value. A PR titled "feat(security)" that only adds unintegrated utility functions has less value than a simple null-check that prevents real crashes.
 - Code that is NOT wired into the running system yet (standalone utilities, helpers not called anywhere) has potential but NOT immediate value — answer Q10, Q11, Q14 as false for unintegrated code.
 - Config/default changes that affect ALL installations or users count as broad impact for Q7.
+- Community contributions (new plugins, skills, integrations, documentation for ecosystem) have value — answer Q5 as true.
+- Security vulnerability fixes (prototype pollution, injection, auth bypass) protect ALL users even if unexploited — they deserve high scores.
+- Documentation that only promotes the author's own unrelated external project is self-promotion, not a contribution.
 
 Questions:
 1. Does this fix a bug that users have reported or would encounter in normal usage?
-2. Does this address a security concern (timing attack, injection, auth bypass, prototype pollution, secret exposure, path traversal, XSS, or similar)?
+2. Does this address a security vulnerability, hardening need, or defense-in-depth concern (timing attack, injection, auth bypass, access control, secret exposure, path traversal, XSS, or similar)?
 3. Does this fix a crash, service failure, or error scenario (null/undefined errors, uncaught exceptions, blank screens, broken workflows, unhandled edge cases)?
 4. Does this solve a performance problem (latency, memory, CPU, resource leaks)?
-5. Does this add a meaningful new user-facing capability or workflow?
+5. Does this add a meaningful new capability, configuration option, integration, or community contribution?
 6. Does this improve developer experience (DX, tooling, debugging, deployment)?
 7. Does the problem affect multiple users, environments, or use cases (broad impact)?
 8. Is the technical approach sound and well-reasoned for the problem at hand?
@@ -316,12 +338,19 @@ Calibration anchors:
 - Typo fix in README: [false,false,false,false,false,false,false,true,false,false,false,false,true,false,false] = 2/15
 - Spam/empty PR with no real changes: [false,false,false,false,false,false,false,false,false,false,false,false,false,false,false] = 0/15
 - Config default changes affecting all users (token optimization, memory settings): [false,false,false,true,false,false,true,true,false,false,true,false,true,false,true] = 6/15
+- Community plugin documentation (new ecosystem skill/plugin page): [false,false,false,false,true,false,false,true,false,false,false,false,true,false,true] = 4/15
+- Security config option for network access control (e.g., strictLoopback): [false,true,false,false,true,false,true,true,false,true,true,false,true,false,true] = 8/15
+- Proactive security hardening (TLS warnings, auth validation, defense-in-depth): [false,true,false,false,false,false,true,true,false,true,true,true,true,true,true] = 9/15
+- Critical security vulnerability fix blocking prototype pollution / injection in template resolver: [false,true,false,false,false,false,true,true,true,true,true,true,true,true,true] = 10/15
+- Crash prevention: catching unhandled I/O write failures that crash the gateway process: [true,false,true,false,false,false,true,true,false,true,true,true,true,true,true] = 10/15
+- Self-promotional documentation page for author's own unrelated external npm package (not integrated with the project): [false,false,false,false,false,false,false,false,false,false,false,false,false,false,false] = 0/15
+- Small focused UX fix: removing stale UI reaction emoji after bot reply in Slack (real reproducible bug, clean fix): [true,false,false,false,false,false,false,true,false,false,true,true,true,false,true] = 6/15
 
 Return JSON: {"answers": [true/false for each of the 15 questions], "risk": "low"|"medium"|"high", "reason": "<1 sentence>"}
-
+${issueCtx}
 ${input}`;
 
-    const text = await this.provider!.generateText(prompt, { temperature: 0.1, maxTokens: 300 });
+    const text = await this.provider!.generateText(prompt, { temperature, maxTokens: 300 });
 
     const match = text.match(/\{[\s\S]*\}/);
     if (!match) throw new Error('No JSON found in LLM response');

--- a/src/core/scoring.ts
+++ b/src/core/scoring.ts
@@ -81,7 +81,7 @@ export class ScoringEngine {
     this.diffAnalyses.set(prNumber, analysis);
   }
 
-  /** Score multiple PRs in parallel with concurrency control */
+  /** Score multiple PRs in parallel with concurrency control + percentile rank */
   async scoreMany(prs: PRData[]): Promise<ScoredPR[]> {
     if (prs.length === 0) return [];
     log.info({ count: prs.length, maxConcurrent: this.concurrency.getMaxConcurrent() }, 'Scoring PRs');
@@ -101,12 +101,23 @@ export class ScoringEngine {
       }
     }
     if (failed > 0) log.warn({ failed, total: prs.length }, 'Some PRs failed to score');
+
+    // Percentile rank normalization
+    scored.sort((a, b) => a.totalScore - b.totalScore);
+    for (let i = 0; i < scored.length; i++) {
+      scored[i].percentileRank = scored.length > 1
+        ? Math.round((i / (scored.length - 1)) * 100)
+        : 50;
+    }
+
     return scored;
   }
 
   async score(pr: PRData): Promise<ScoredPR> {
+    // 1. Intent classification
     const intentResult = await this.intentClassifier.classify(pr.title, pr.body ?? '', pr.changedFiles);
 
+    // 2. All 21 signals (4A: missing=0, 4B: contributor weight=0.04, 4C: intent=0)
     const signals: SignalScore[] = [
       this.scoreCI(pr),
       this.scoreDiffSize(pr),
@@ -131,7 +142,7 @@ export class ScoringEngine {
       this.scoreIntent(intentResult),
     ];
 
-    // Apply intent-aware weight profiles
+    // 3. Intent profile weight overrides + normalization
     const profile = INTENT_PROFILES[intentResult.intent];
     if (profile) {
       for (const signal of signals) {
@@ -149,46 +160,59 @@ export class ScoringEngine {
       }
     }
 
-    const totalWeight = signals.reduce((sum, s) => sum + s.weight, 0);
-    const heuristicScore = totalWeight > 0
-      ? signals.reduce((sum, s) => sum + s.score * s.weight, 0) / totalWeight
-      : 0;
+    // 4. TOPSIS readiness score
+    const topsisScore = this.calculateTOPSIS(signals);
 
+    // 5. Spam detection
     const spamSignal = signals.find(s => s.name === 'spam');
     const isSpam = (spamSignal?.score ?? 100) < 25;
 
-    // LLM scoring
-    let llmScore: number | undefined;
+    // 6. Hard penalties on readiness
+    let penaltyMultiplier = 1.0;
+    if (pr.ciStatus === 'failure') penaltyMultiplier *= 0.4;
+    if (pr.mergeable === 'conflicting') penaltyMultiplier *= 0.5;
+    if (isSpam) penaltyMultiplier *= 0.2;
+    if (pr.isDraft) penaltyMultiplier *= 0.4;
+    const isAbandoned = pr.ageInDays > 180 && pr.commentCount <= 1 && pr.reviewState === 'none';
+    if (isAbandoned) penaltyMultiplier *= 0.3;
+    const readinessScore = Math.round(Math.max(0, Math.min(100, topsisScore * penaltyMultiplier)));
+
+    // 7. LLM idea scoring
+    let ideaScore: number | undefined;
+    let ideaReason: string | undefined;
     let llmRisk: 'low' | 'medium' | 'high' | undefined;
-    let llmReason: string | undefined;
 
     if (this.provider) {
       try {
         const llmResult = await this.scoreLLM(pr);
-        llmScore = llmResult.score;
+        ideaScore = llmResult.score;
+        ideaReason = llmResult.reason;
         llmRisk = llmResult.risk;
-        llmReason = llmResult.reason;
       } catch (err: any) {
-        llmReason = `LLM failed: ${err.message}`;
+        ideaReason = `LLM failed: ${err.message}`;
         log.warn({ pr: pr.number, err }, 'LLM scoring failed');
       }
     }
 
-    // Blend: new formula when diff available
+    // 8. Diff analysis bonus (if available)
     const diffAnalysis = this.diffAnalyses.get(pr.number);
-    let totalScore: number;
-    if (llmScore !== undefined && diffAnalysis) {
-      // 0.4 heuristic + 0.3 LLM text + 0.3 LLM diff
-      totalScore = Math.round(0.4 * heuristicScore + 0.3 * llmScore + 0.3 * diffAnalysis.codeQuality);
-      // Override risk from diff (more reliable)
+    if (diffAnalysis && ideaScore !== undefined) {
+      ideaScore = Math.round(0.6 * ideaScore + 0.4 * diffAnalysis.codeQuality);
       if (diffAnalysis.riskAssessment !== 'medium') {
         llmRisk = diffAnalysis.riskAssessment === 'critical' ? 'high' : diffAnalysis.riskAssessment;
       }
-    } else if (llmScore !== undefined) {
-      totalScore = Math.round(0.4 * heuristicScore + 0.6 * llmScore);
-    } else {
-      totalScore = Math.round(heuristicScore);
     }
+
+    // 9. Combined total score
+    let totalScore: number;
+    if (ideaScore !== undefined) {
+      totalScore = Math.round(0.7 * ideaScore + 0.3 * readinessScore);
+    } else {
+      totalScore = readinessScore; // no LLM = readiness only
+    }
+
+    // 10. Tier classification
+    const tier = this.assignTier(ideaScore ?? readinessScore, readinessScore);
 
     return {
       ...pr,
@@ -197,19 +221,76 @@ export class ScoringEngine {
       isSpam,
       spamReasons: isSpam ? [spamSignal?.reason ?? 'Low quality'] : [],
       visionAlignment: 'unchecked',
-      llmScore,
+      // backward compat
+      llmScore: ideaScore,
       llmRisk,
-      llmReason,
+      llmReason: ideaReason,
       intent: intentResult.intent,
       diffAnalysis,
+      // v0.8 dual scoring
+      ideaScore,
+      ideaReason,
+      readinessScore,
+      penaltyMultiplier,
+      tier,
     };
+  }
+
+  /** TOPSIS — distance to ideal/anti-ideal for natural score spread */
+  private calculateTOPSIS(signals: SignalScore[]): number {
+    const active = signals.filter(s => s.weight > 0);
+    if (active.length === 0) return 0;
+
+    // Weighted normalized values
+    const weighted = active.map(s => (s.score / 100) * s.weight);
+    const weights = active.map(s => s.weight);
+
+    // Distance to ideal (all signals = 100)
+    const dPlus = Math.sqrt(
+      weighted.reduce((sum, v, i) => sum + Math.pow(weights[i] - v, 2), 0)
+    );
+    // Distance to anti-ideal (all signals = 0)
+    const dMinus = Math.sqrt(
+      weighted.reduce((sum, v) => sum + Math.pow(v, 2), 0)
+    );
+
+    if (dPlus + dMinus === 0) return 0;
+    return (dMinus / (dPlus + dMinus)) * 100;
+  }
+
+  /** Assign priority tier based on ideaScore + readinessScore */
+  private assignTier(ideaScore: number, readinessScore: number): 'critical' | 'high' | 'normal' | 'low' {
+    if (ideaScore >= 80 && readinessScore >= 60) return 'critical';
+    if (ideaScore >= 70) return 'high';
+    if (ideaScore >= 45) return 'normal';
+    return 'low';
   }
 
   private async scoreLLM(pr: PRData): Promise<{ score: number; risk: 'low' | 'medium' | 'high'; reason: string }> {
     const filesStr = pr.changedFiles.slice(0, 30).join(', ');
     const input = `Title: ${pr.title}\nBody: ${(pr.body ?? '').slice(0, 2000)}\nFiles: ${filesStr}`.slice(0, 4000);
 
-    const prompt = `Rate this GitHub PR on practical value and merge-readiness (0-100). Focus on: Does it solve a real problem? Is the implementation correct and complete? Would merging it improve the project? Ignore whether AI/LLM was used to write it — only judge the end result. Return JSON: {"score": <number>, "risk": "low"|"medium"|"high", "reason": "<brief>"}\nRisk means: would merging this PR cause issues (breaking changes, bugs, security)?\n${input}`;
+    const prompt = `Evaluate the IDEA VALUE of this PR — how valuable is the problem it solves and the approach it takes? Score the IDEA, not the PR quality.
+
+A brilliant fix with poor tests still has high idea value.
+A polished PR fixing a typo has low idea value.
+
+Rubric (use the FULL range):
+  90-100: Critical fix for a real production problem (security, data loss, crash)
+  75-89: Valuable improvement solving a genuine pain point
+  50-74: Useful but routine fix or minor enhancement
+  25-49: Low-value change (cosmetic, trivial, or unnecessary)
+  0-24: No practical value (spam, duplicate, or harmful)
+
+Consider:
+- Does this solve a REAL problem users/developers face?
+- Is the approach/idea sound (even if implementation is rough)?
+- Would YOU want this change in your codebase?
+- Is this a novel insight or a copy of an obvious pattern?
+
+Return JSON: {"score": <0-100>, "risk": "low"|"medium"|"high", "reason": "<1 sentence: what makes this valuable or not>"}
+
+${input}`;
 
     const text = await this.provider!.generateText(prompt, { temperature: 0.1, maxTokens: 200 });
 
@@ -230,7 +311,7 @@ export class ScoringEngine {
   // --- Original 13 signals (weights adjusted for 18-signal total) ---
 
   private scoreCI(pr: PRData): SignalScore {
-    const scoreMap = { success: 100, pending: 50, failure: 10, unknown: 40 };
+    const scoreMap = { success: 100, pending: 50, failure: 10, unknown: 0 };
     return { name: 'ci_status', score: scoreMap[pr.ciStatus], weight: 0.15, reason: `CI: ${pr.ciStatus}` };
   }
 
@@ -253,7 +334,7 @@ export class ScoringEngine {
   private scoreContributor(pr: PRData): SignalScore {
     const trustMap: Record<string, number> = {
       OWNER: 100, MEMBER: 90, COLLABORATOR: 85, CONTRIBUTOR: 70,
-      FIRST_TIMER: 40, FIRST_TIME_CONTRIBUTOR: 40, NONE: 30,
+      FIRST_TIMER: 25, FIRST_TIME_CONTRIBUTOR: 25, NONE: 15,
     };
     let assocScore = trustMap[pr.authorAssociation] ?? 50;
     const repScore = this.reputationScores.get(pr.author);
@@ -261,12 +342,12 @@ export class ScoringEngine {
       ? Math.round(0.7 * assocScore + 0.3 * repScore)
       : assocScore;
     const repInfo = repScore !== undefined ? `, rep: ${repScore}` : '';
-    return { name: 'contributor', score, weight: 0.12, reason: `${pr.author} (${pr.authorAssociation}${repInfo})` };
+    return { name: 'contributor', score, weight: 0.04, reason: `${pr.author} (${pr.authorAssociation}${repInfo})` };
   }
 
   private scoreIssueRef(pr: PRData): SignalScore {
     return {
-      name: 'issue_ref', score: pr.hasIssueRef ? 90 : 30, weight: 0.07,
+      name: 'issue_ref', score: pr.hasIssueRef ? 90 : 0, weight: 0.07,
       reason: pr.hasIssueRef ? `References: ${pr.issueNumbers.map(n => `#${n}`).join(', ')}` : 'No issue reference',
     };
   }
@@ -359,7 +440,7 @@ export class ScoringEngine {
 
   private scoreReviewStatus(pr: PRData): SignalScore {
     const stateScores: Record<string, number> = {
-      approved: 100, changes_requested: 30, commented: 60, none: 40,
+      approved: 100, changes_requested: 30, commented: 60, none: 0,
     };
     let score = stateScores[pr.reviewState] ?? 40;
     if (pr.reviewCount >= 2) score = Math.min(100, score + 10);
@@ -383,7 +464,7 @@ export class ScoringEngine {
     if (pr.commentCount >= 5) score = 90;
     else if (pr.commentCount >= 2) score = 70;
     else if (pr.commentCount === 1) score = 50;
-    else score = 30;
+    else score = 0;
     return { name: 'activity', score, weight: 0.04, reason: `${pr.commentCount} comments` };
   }
 
@@ -429,7 +510,7 @@ export class ScoringEngine {
   private scoreMilestone(pr: PRData): SignalScore {
     return {
       name: 'milestone',
-      score: pr.milestone ? 90 : 40,
+      score: pr.milestone ? 90 : 0,
       weight: 0.07,
       reason: pr.milestone ? `Milestone: ${pr.milestone}` : 'No milestone attached',
     };
@@ -446,12 +527,12 @@ export class ScoringEngine {
     if (labels.some(l => lowLabels.some(h => l.includes(h)))) {
       return { name: 'label_priority', score: 30, weight: 0.08, reason: `Low priority labels: ${pr.labels.join(', ')}` };
     }
-    return { name: 'label_priority', score: 50, weight: 0.05, reason: pr.labels.length > 0 ? `Labels: ${pr.labels.join(', ')}` : 'No priority labels' };
+    return { name: 'label_priority', score: 0, weight: 0.05, reason: pr.labels.length > 0 ? `Labels: ${pr.labels.join(', ')}` : 'No priority labels' };
   }
 
   private scoreCodeowners(pr: PRData): SignalScore {
     if (pr.codeowners.length === 0) {
-      return { name: 'codeowners', score: 40, weight: 0.05, reason: 'No CODEOWNERS match' };
+      return { name: 'codeowners', score: 0, weight: 0.05, reason: 'No CODEOWNERS match' };
     }
     const authorIsOwner = pr.codeowners.includes(pr.author);
     return {
@@ -467,7 +548,7 @@ export class ScoringEngine {
   private scoreRequestedReviewers(pr: PRData): SignalScore {
     return {
       name: 'requested_reviewers',
-      score: pr.requestedReviewers.length > 0 ? 80 : 40,
+      score: pr.requestedReviewers.length > 0 ? 80 : 0,
       weight: 0.05,
       reason: pr.requestedReviewers.length > 0
         ? `${pr.requestedReviewers.length} reviewer(s): ${pr.requestedReviewers.slice(0, 3).join(', ')}`
@@ -523,13 +604,11 @@ export class ScoringEngine {
   }
 
   private scoreIntent(result: IntentResult): SignalScore {
-    const scores: Record<string, number> = {
-      bugfix: 90, feature: 85, refactor: 60, dependency: 35, docs: 30, chore: 25,
-    };
+    // Intent only affects scoring via INTENT_PROFILES weight overrides, not its own score
     return {
       name: 'intent',
-      score: scores[result.intent] ?? 50,
-      weight: 0.15,
+      score: 0,
+      weight: 0,
       reason: `${result.intent} (${result.reason})`,
     };
   }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -68,7 +68,7 @@ export interface ScoredPR extends PRData {
   visionAlignment?: 'aligned' | 'tangential' | 'off-roadmap' | 'unchecked';
   visionScore?: number;        // 0-100 LLM vision alignment score
   visionReason?: string;
-  llmScore?: number;           // 0-100 LLM quality score
+  llmScore?: number;           // 0-100 LLM quality score (backward compat — maps to ideaScore)
   llmRisk?: 'low' | 'medium' | 'high';
   llmReason?: string;
   duplicateGroup?: number;     // Cluster ID if part of a duplicate group
@@ -79,6 +79,18 @@ export interface ScoredPR extends PRData {
   semanticMatches?: SemanticMatch[];
   holisticRank?: number;
   adjustedScore?: number;
+  /** Idea/fix value score (0-100) — how valuable is the core idea? */
+  ideaScore?: number;
+  /** Why this score for idea value */
+  ideaReason?: string;
+  /** Merge-readiness score (0-100) — how ready is this PR? */
+  readinessScore?: number;
+  /** Hard penalty multiplier applied to readiness */
+  penaltyMultiplier?: number;
+  /** Percentile rank within scored batch */
+  percentileRank?: number;
+  /** Priority tier based on combined scores */
+  tier?: 'critical' | 'high' | 'normal' | 'low';
 }
 
 export type IntentCategory = 'bugfix' | 'feature' | 'refactor' | 'dependency' | 'docs' | 'chore';

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -85,9 +85,15 @@ export interface ScoredPR extends PRData {
   ideaScore?: number;
   /** Why this score for idea value */
   ideaReason?: string;
-  /** Binary checklist answers from CheckEval (15 yes/no questions) */
+  /** Binary checklist answers from CheckEval idea questions */
   ideaChecklist?: boolean[];
-  /** Merge-readiness score (0-100) — how ready is this PR? */
+  /** Implementation quality score (0-100) — how well is the code implemented? */
+  implementationScore?: number;
+  /** Why this score for implementation */
+  implementationReason?: string;
+  /** Binary checklist answers from CheckEval implementation questions */
+  implementationChecklist?: boolean[];
+  /** Merge-readiness score (0-100) — heuristic signals via TOPSIS */
   readinessScore?: number;
   /** Hard penalty multiplier applied to readiness */
   penaltyMultiplier?: number;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -83,6 +83,8 @@ export interface ScoredPR extends PRData {
   ideaScore?: number;
   /** Why this score for idea value */
   ideaReason?: string;
+  /** Binary checklist answers from CheckEval (15 yes/no questions) */
+  ideaChecklist?: boolean[];
   /** Merge-readiness score (0-100) — how ready is this PR? */
   readinessScore?: number;
   /** Hard penalty multiplier applied to readiness */

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -19,6 +19,12 @@ export interface TreliqConfig {
   useCache: boolean;           // Use incremental cache (default: true)
   cacheFile: string;           // Cache file path (default: '.treliq-cache.json')
   dbPath?: string;             // SQLite database path (undefined = no DB)
+  cascade?: {
+    enabled: boolean;
+    reScoreProvider?: LLMProvider;
+    preFilterThreshold?: number;
+    haikuThreshold?: number;
+  };
 }
 
 export interface PRData {
@@ -54,6 +60,8 @@ export interface PRData {
   codeowners: string[];
   /** Optional linked issue description for LLM context enrichment */
   issueContext?: string;
+  /** PR state for readyToSteal detection */
+  state?: 'open' | 'closed' | 'merged';
 }
 
 export interface SignalScore {
@@ -101,6 +109,12 @@ export interface ScoredPR extends PRData {
   percentileRank?: number;
   /** Priority tier based on combined scores */
   tier?: 'critical' | 'high' | 'normal' | 'low';
+  /** Which model scored this PR */
+  scoredBy?: 'heuristic' | 'haiku' | 'sonnet';
+  /** Ready to steal: high-value closed PR we can re-implement */
+  readyToSteal?: boolean;
+  /** Novelty bonus (0-20) from CheckEval Part C */
+  noveltyBonus?: number;
 }
 
 export type IntentCategory = 'bugfix' | 'feature' | 'refactor' | 'dependency' | 'docs' | 'chore';
@@ -175,4 +189,19 @@ export interface TreliqResult {
   rankedPRs: ScoredPR[];       // Sorted by totalScore desc
   rankedIssues?: ScoredIssue[];
   summary: string;
+}
+
+export interface CascadeConfig {
+  enabled: boolean;
+  reScoreProvider: LLMProvider;
+  preFilterThreshold?: number;  // default: 15
+  haikuThreshold?: number;      // default: 40
+}
+
+export interface ScoringEngineOptions {
+  provider?: LLMProvider;
+  trustContributors?: boolean;
+  maxConcurrent?: number;
+  scoringPasses?: number;
+  cascade?: CascadeConfig;
 }

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -52,6 +52,8 @@ export interface PRData {
   milestone?: string;
   requestedReviewers: string[];
   codeowners: string[];
+  /** Optional linked issue description for LLM context enrichment */
+  issueContext?: string;
 }
 
 export interface SignalScore {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ export { ActionExecutor } from './core/action-executor';
 export { DiffAnalyzer } from './core/diff-analyzer';
 export { SemanticMatcher } from './core/semantic-matcher';
 export { HolisticRanker } from './core/holistic-ranker';
-export type { PRData, ScoredPR, ScoredIssue, IssueData, DedupCluster, TreliqConfig, TreliqResult, TriageItem, DiffAnalysis, SemanticMatch } from './core/types';
+export type { PRData, ScoredPR, ScoredIssue, IssueData, DedupCluster, TreliqConfig, TreliqResult, TriageItem, DiffAnalysis, SemanticMatch, CascadeConfig, ScoringEngineOptions } from './core/types';
 export type { ActionItem, ActionOptions } from './core/actions';
 export type { ExecutionResult } from './core/action-executor';
 export { loadCache, saveCache, configHash } from './core/cache';

--- a/test/fixtures/mock-provider.ts
+++ b/test/fixtures/mock-provider.ts
@@ -4,12 +4,23 @@
 
 import type { LLMProvider } from '../../src/core/provider';
 
+/**
+ * Helper to create a CheckEval-format JSON response for mock LLM.
+ * ideaScore = Math.round((yesCount / 15) * 100)
+ *
+ * Score mapping: 0→0, 3→20, 5→33, 7→47, 8→53, 9→60, 10→67, 11→73, 12→80, 13→87, 14→93, 15→100
+ */
+export function checklistResponse(yesCount: number, risk = 'low', reason = 'Test'): string {
+  const answers = Array.from({ length: 15 }, (_, i) => i < yesCount);
+  return JSON.stringify({ answers, risk, reason });
+}
+
 export class MockLLMProvider implements LLMProvider {
   name = 'mock';
 
   // Configurable responses
   generateTextResponse: string | ((prompt: string) => string | Promise<string>) =
-    '{"score": 75, "risk": "low", "reason": "Mock LLM response"}';
+    checklistResponse(11, 'low', 'Mock LLM response');
   generateEmbeddingResponse: number[] | ((text: string) => number[] | Promise<number[]>) =
     Array(768).fill(0).map((_, i) => Math.sin(i * 0.1) * 0.1);
 
@@ -58,7 +69,7 @@ export class MockLLMProvider implements LLMProvider {
     this.generateTextCalls = [];
     this.generateEmbeddingCalls = [];
     this.generateEmbeddingBatchCalls = [];
-    this.generateTextResponse = '{"score": 75, "risk": "low", "reason": "Mock LLM response"}';
+    this.generateTextResponse = checklistResponse(11, 'low', 'Mock LLM response');
     this.generateEmbeddingResponse = Array(768).fill(0).map((_, i) => Math.sin(i * 0.1) * 0.1);
     this.generateEmbeddingBatchResponse = null;
   }

--- a/test/fixtures/mock-provider.ts
+++ b/test/fixtures/mock-provider.ts
@@ -5,17 +5,17 @@
 import type { LLMProvider } from '../../src/core/provider';
 
 /**
- * Helper to create a dual CheckEval response (idea + implementation).
- * ideaScore = Math.round((ideaYes / 10) * 100)
+ * Helper to create a hybrid CheckEval response (idea + implementation + noveltyBonus).
+ * ideaScore = min(100, ideaYes * 8 + noveltyBonus)
  * implementationScore = Math.round((implYes / 5) * 100)
  *
- * Idea score mapping: 0→0, 1→10, 2→20, 3→30, 4→40, 5→50, 6→60, 7→70, 8→80, 9→90, 10→100
+ * Idea score: base 0-80 from binary + 0-20 bonus = fine-grained 0-100
  * Impl score mapping: 0→0, 1→20, 2→40, 3→60, 4→80, 5→100
  */
-export function dualChecklistResponse(ideaYes: number, implYes: number, risk = 'low', reason = 'Test'): string {
+export function dualChecklistResponse(ideaYes: number, implYes: number, risk = 'low', reason = 'Test', noveltyBonus = 0): string {
   const idea = Array.from({ length: 10 }, (_, i) => i < ideaYes);
   const implementation = Array.from({ length: 5 }, (_, i) => i < implYes);
-  return JSON.stringify({ idea, implementation, risk, reason });
+  return JSON.stringify({ idea, implementation, noveltyBonus, risk, reason });
 }
 
 /**
@@ -26,7 +26,9 @@ export function checklistResponse(yesCount: number, risk = 'low', reason = 'Test
   // Map old 15-question count to new dual format: split proportionally
   const ideaYes = Math.min(10, Math.round(yesCount * (10 / 15)));
   const implYes = Math.min(5, yesCount - ideaYes);
-  return dualChecklistResponse(ideaYes, implYes, risk, reason);
+  // Legacy: estimate novelty bonus proportional to yes count
+  const noveltyBonus = Math.round((yesCount / 15) * 12);
+  return dualChecklistResponse(ideaYes, implYes, risk, reason, noveltyBonus);
 }
 
 export class MockLLMProvider implements LLMProvider {
@@ -34,7 +36,7 @@ export class MockLLMProvider implements LLMProvider {
 
   // Configurable responses
   generateTextResponse: string | ((prompt: string) => string | Promise<string>) =
-    dualChecklistResponse(7, 4, 'low', 'Mock LLM response');
+    dualChecklistResponse(7, 4, 'low', 'Mock LLM response', 12);
   generateEmbeddingResponse: number[] | ((text: string) => number[] | Promise<number[]>) =
     Array(768).fill(0).map((_, i) => Math.sin(i * 0.1) * 0.1);
 
@@ -83,7 +85,7 @@ export class MockLLMProvider implements LLMProvider {
     this.generateTextCalls = [];
     this.generateEmbeddingCalls = [];
     this.generateEmbeddingBatchCalls = [];
-    this.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Mock LLM response');
+    this.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Mock LLM response', 12);
     this.generateEmbeddingResponse = Array(768).fill(0).map((_, i) => Math.sin(i * 0.1) * 0.1);
     this.generateEmbeddingBatchResponse = null;
   }

--- a/test/fixtures/mock-provider.ts
+++ b/test/fixtures/mock-provider.ts
@@ -5,14 +5,28 @@
 import type { LLMProvider } from '../../src/core/provider';
 
 /**
- * Helper to create a CheckEval-format JSON response for mock LLM.
- * ideaScore = Math.round((yesCount / 15) * 100)
+ * Helper to create a dual CheckEval response (idea + implementation).
+ * ideaScore = Math.round((ideaYes / 10) * 100)
+ * implementationScore = Math.round((implYes / 5) * 100)
  *
- * Score mapping: 0→0, 3→20, 5→33, 7→47, 8→53, 9→60, 10→67, 11→73, 12→80, 13→87, 14→93, 15→100
+ * Idea score mapping: 0→0, 1→10, 2→20, 3→30, 4→40, 5→50, 6→60, 7→70, 8→80, 9→90, 10→100
+ * Impl score mapping: 0→0, 1→20, 2→40, 3→60, 4→80, 5→100
+ */
+export function dualChecklistResponse(ideaYes: number, implYes: number, risk = 'low', reason = 'Test'): string {
+  const idea = Array.from({ length: 10 }, (_, i) => i < ideaYes);
+  const implementation = Array.from({ length: 5 }, (_, i) => i < implYes);
+  return JSON.stringify({ idea, implementation, risk, reason });
+}
+
+/**
+ * @deprecated Use dualChecklistResponse instead. Kept for backward compat during migration.
+ * Creates a legacy 15-question response (first 10 = idea, last 5 = impl).
  */
 export function checklistResponse(yesCount: number, risk = 'low', reason = 'Test'): string {
-  const answers = Array.from({ length: 15 }, (_, i) => i < yesCount);
-  return JSON.stringify({ answers, risk, reason });
+  // Map old 15-question count to new dual format: split proportionally
+  const ideaYes = Math.min(10, Math.round(yesCount * (10 / 15)));
+  const implYes = Math.min(5, yesCount - ideaYes);
+  return dualChecklistResponse(ideaYes, implYes, risk, reason);
 }
 
 export class MockLLMProvider implements LLMProvider {
@@ -20,7 +34,7 @@ export class MockLLMProvider implements LLMProvider {
 
   // Configurable responses
   generateTextResponse: string | ((prompt: string) => string | Promise<string>) =
-    checklistResponse(11, 'low', 'Mock LLM response');
+    dualChecklistResponse(7, 4, 'low', 'Mock LLM response');
   generateEmbeddingResponse: number[] | ((text: string) => number[] | Promise<number[]>) =
     Array(768).fill(0).map((_, i) => Math.sin(i * 0.1) * 0.1);
 
@@ -69,7 +83,7 @@ export class MockLLMProvider implements LLMProvider {
     this.generateTextCalls = [];
     this.generateEmbeddingCalls = [];
     this.generateEmbeddingBatchCalls = [];
-    this.generateTextResponse = checklistResponse(11, 'low', 'Mock LLM response');
+    this.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Mock LLM response');
     this.generateEmbeddingResponse = Array(768).fill(0).map((_, i) => Math.sin(i * 0.1) * 0.1);
     this.generateEmbeddingBatchResponse = null;
   }

--- a/test/fixtures/pr-factory.ts
+++ b/test/fixtures/pr-factory.ts
@@ -39,6 +39,7 @@ export function createPRData(overrides: Partial<PRData> = {}): PRData {
     milestone: undefined,
     requestedReviewers: ['reviewer1'],
     codeowners: ['testuser'],
+    state: 'open',
   };
 
   return { ...defaults, ...overrides };
@@ -95,6 +96,9 @@ export function createScoredPR(overrides: Partial<ScoredPR> = {}): ScoredPR {
     penaltyMultiplier: undefined,
     percentileRank: undefined,
     tier: undefined,
+    scoredBy: undefined,
+    readyToSteal: false,
+    noveltyBonus: undefined,
   };
 
   const signals = overrides.signals ?? defaultSignals;

--- a/test/fixtures/pr-factory.ts
+++ b/test/fixtures/pr-factory.ts
@@ -54,7 +54,7 @@ export function createScoredPR(overrides: Partial<ScoredPR> = {}): ScoredPR {
     { name: 'ci_status', score: 100, weight: 0.15, reason: 'CI: success' },
     { name: 'diff_size', score: 100, weight: 0.07, reason: '120 lines changed (100+/20-)' },
     { name: 'commit_quality', score: 90, weight: 0.04, reason: 'Conventional commit format' },
-    { name: 'contributor', score: 70, weight: 0.12, reason: 'testuser (CONTRIBUTOR)' },
+    { name: 'contributor', score: 70, weight: 0.04, reason: 'testuser (CONTRIBUTOR)' },
     { name: 'issue_ref', score: 90, weight: 0.07, reason: 'References: #42' },
     { name: 'spam', score: 100, weight: 0.12, reason: 'No spam signals' },
     { name: 'test_coverage', score: 90, weight: 0.12, reason: '1 test file(s) changed' },
@@ -65,10 +65,13 @@ export function createScoredPR(overrides: Partial<ScoredPR> = {}): ScoredPR {
     { name: 'activity', score: 90, weight: 0.04, reason: '5 comments' },
     { name: 'breaking_change', score: 80, weight: 0.04, reason: 'No breaking change signals' },
     { name: 'draft_status', score: 90, weight: 0.08, reason: 'Ready for review' },
-    { name: 'milestone', score: 40, weight: 0.07, reason: 'No milestone attached' },
-    { name: 'label_priority', score: 50, weight: 0.05, reason: 'No priority labels' },
+    { name: 'milestone', score: 0, weight: 0.07, reason: 'No milestone attached' },
+    { name: 'label_priority', score: 0, weight: 0.05, reason: 'No priority labels' },
     { name: 'codeowners', score: 95, weight: 0.10, reason: 'Author owns 1 matched pattern(s)' },
     { name: 'requested_reviewers', score: 80, weight: 0.05, reason: '1 reviewer(s): reviewer1' },
+    { name: 'scope_coherence', score: 70, weight: 0.06, reason: 'normal: 2 area(s)' },
+    { name: 'complexity', score: 80, weight: 0.05, reason: 'proportional: 120 lines, 3 files' },
+    { name: 'intent', score: 0, weight: 0, reason: 'feature (conventional prefix)' },
   ];
 
   const defaults: ScoredPR = {
@@ -86,6 +89,12 @@ export function createScoredPR(overrides: Partial<ScoredPR> = {}): ScoredPR {
     visionScore: undefined,
     visionReason: undefined,
     intent: overrides.intent,
+    ideaScore: undefined,
+    ideaReason: undefined,
+    readinessScore: undefined,
+    penaltyMultiplier: undefined,
+    percentileRank: undefined,
+    tier: undefined,
   };
 
   const signals = overrides.signals ?? defaultSignals;

--- a/test/integration/scoring-engine.test.ts
+++ b/test/integration/scoring-engine.test.ts
@@ -4,7 +4,7 @@
 
 import { ScoringEngine } from '../../src/core/scoring';
 import { createPRData } from '../fixtures/pr-factory';
-import { MockLLMProvider, checklistResponse } from '../fixtures/mock-provider';
+import { MockLLMProvider, dualChecklistResponse } from '../fixtures/mock-provider';
 
 describe('ScoringEngine', () => {
   describe('Heuristic-only scoring (no LLM)', () => {
@@ -48,11 +48,11 @@ describe('ScoringEngine', () => {
     });
   });
 
-  describe('LLM blend scoring', () => {
-    it('should blend heuristic and LLM scores', async () => {
+  describe('LLM dual scoring', () => {
+    it('should produce idea + implementation scores', async () => {
       const provider = new MockLLMProvider();
-      // 11 yes → ideaScore=73
-      provider.generateTextResponse = checklistResponse(11, 'low', 'Good implementation');
+      // 7/10 idea → 70, 4/5 impl → 80
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Good implementation');
 
       const engine = new ScoringEngine(provider);
       const pr = createPRData({
@@ -65,26 +65,28 @@ describe('ScoringEngine', () => {
 
       const scored = await engine.score(pr);
 
-      expect(scored.llmScore).toBe(73);
+      expect(scored.llmScore).toBe(70);  // backward compat = ideaScore
+      expect(scored.ideaScore).toBe(70);
+      expect(scored.implementationScore).toBe(80);
       expect(scored.llmRisk).toBe('low');
       expect(scored.llmReason).toBe('Good implementation');
 
-      // totalScore = geometric mean of ideaScore and readinessScore
-      expect(scored.totalScore).toBeGreaterThan(0);
-      expect(scored.totalScore).toBeLessThanOrEqual(100);
+      // totalScore = 0.7 * idea + 0.3 * implementation
+      expect(scored.totalScore).toBe(Math.round(0.7 * 70 + 0.3 * 80));
 
-      // Verify provider was called with checklist prompt
+      // Verify provider was called with dual checklist prompt
       expect(provider.generateTextCalls.length).toBe(1);
       expect(provider.generateTextCalls[0].prompt).toContain('feat: add authentication');
+      expect(provider.generateTextCalls[0].prompt).toContain('PART A');
+      expect(provider.generateTextCalls[0].prompt).toContain('PART B');
     });
 
-    it('should use weighted geometric mean formula', async () => {
+    it('should use weighted average formula', async () => {
       const provider = new MockLLMProvider();
-      // 12 yes → ideaScore=80
-      provider.generateTextResponse = checklistResponse(12, 'low', 'Test');
+      // 8/10 idea → 80, 5/5 impl → 100
+      provider.generateTextResponse = dualChecklistResponse(8, 5, 'low', 'Test');
 
       const engine = new ScoringEngine(provider);
-
       const pr = createPRData({
         ciStatus: 'success',
         additions: 200,
@@ -98,35 +100,32 @@ describe('ScoringEngine', () => {
 
       const scored = await engine.score(pr);
 
-      // v0.8: totalScore = idea^0.65 * readiness^0.35 (geometric mean)
-      const safeIdea = Math.max(5, scored.ideaScore!);
-      const safeReadiness = Math.max(5, scored.readinessScore!);
-      const expected = Math.round(Math.pow(safeIdea, 0.65) * Math.pow(safeReadiness, 0.35));
-
       expect(scored.ideaScore).toBe(80);
+      expect(scored.implementationScore).toBe(100);
       expect(scored.llmScore).toBe(80); // backward compat
-      expect(scored.totalScore).toBe(expected);
+      // totalScore = round(0.7 * 80 + 0.3 * 100) = round(56 + 30) = 86
+      expect(scored.totalScore).toBe(86);
     });
 
     it('should handle different LLM risk levels', async () => {
       const provider = new MockLLMProvider();
 
       // Test low risk
-      provider.generateTextResponse = checklistResponse(14, 'low', 'Safe change');
+      provider.generateTextResponse = dualChecklistResponse(9, 5, 'low', 'Safe change');
       let engine = new ScoringEngine(provider);
       let scored = await engine.score(createPRData());
       expect(scored.llmRisk).toBe('low');
 
       // Test medium risk
       provider.reset();
-      provider.generateTextResponse = checklistResponse(9, 'medium', 'Some concerns');
+      provider.generateTextResponse = dualChecklistResponse(5, 3, 'medium', 'Some concerns');
       engine = new ScoringEngine(provider);
       scored = await engine.score(createPRData());
       expect(scored.llmRisk).toBe('medium');
 
       // Test high risk
       provider.reset();
-      provider.generateTextResponse = checklistResponse(5, 'high', 'Breaking changes');
+      provider.generateTextResponse = dualChecklistResponse(3, 1, 'high', 'Breaking changes');
       engine = new ScoringEngine(provider);
       scored = await engine.score(createPRData());
       expect(scored.llmRisk).toBe('high');
@@ -163,8 +162,8 @@ describe('ScoringEngine', () => {
 
     it('should process PRs with LLM provider', async () => {
       const provider = new MockLLMProvider();
-      // 11 yes → ideaScore=73
-      provider.generateTextResponse = checklistResponse(11, 'low', 'Good');
+      // 7/10 idea → 70, 4/5 impl → 80
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Good');
 
       const engine = new ScoringEngine(provider);
       const prs = [
@@ -175,8 +174,8 @@ describe('ScoringEngine', () => {
       const results = await engine.scoreMany(prs);
 
       expect(results).toHaveLength(2);
-      expect(results[0].llmScore).toBe(73); // 11/15 * 100
-      expect(results[1].llmScore).toBe(73);
+      expect(results[0].llmScore).toBe(70); // 7/10 * 100
+      expect(results[1].llmScore).toBe(70);
       expect(provider.generateTextCalls.length).toBe(2);
     });
   });
@@ -219,15 +218,18 @@ describe('ScoringEngine', () => {
 
     it('should fall back on malformed LLM response', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"invalid": "response"}'; // Missing score/risk/reason
+      provider.generateTextResponse = '{"invalid": "response"}'; // Missing idea/implementation arrays
 
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
 
       const scored = await engine.score(pr);
 
-      // Should still work, potentially with default/clamped values
-      expect(scored.totalScore).toBeGreaterThan(0);
+      // Malformed response: idea=0/10, impl=0/5, both scores are 0
+      // totalScore = 0.7*0 + 0.3*0 = 0 — but scoring still completes
+      expect(scored.totalScore).toBeGreaterThanOrEqual(0);
+      expect(scored.ideaScore).toBe(0);
+      expect(scored.implementationScore).toBe(0);
     });
   });
 
@@ -393,10 +395,10 @@ describe('ScoringEngine', () => {
   });
 
   describe('Diff-enriched scoring blend', () => {
-    it('blends ideaScore with diff codeQuality when diff analysis available', async () => {
+    it('blends implementationScore with diff codeQuality when diff analysis available', async () => {
       const provider = new MockLLMProvider();
-      // 12 yes → base ideaScore=80
-      provider.generateTextResponse = checklistResponse(12, 'low', 'Good PR');
+      // 8/10 idea → 80, 4/5 impl → 80
+      provider.generateTextResponse = dualChecklistResponse(8, 4, 'low', 'Good PR');
 
       const engine = new ScoringEngine(provider);
       engine.setDiffAnalysis(1, {
@@ -411,21 +413,19 @@ describe('ScoringEngine', () => {
       const pr = createPRData({ number: 1, title: 'fix: improve error handling' });
       const scored = await engine.score(pr);
 
-      // v0.8: ideaScore = 0.6 * checklist + 0.4 * diffQuality = 0.6 * 80 + 0.4 * 90 = 84
+      // v0.8: implementationScore = 0.6 * checklist + 0.4 * diffQuality = 0.6 * 80 + 0.4 * 90 = 84
       expect(scored.diffAnalysis).toBeDefined();
       expect(scored.diffAnalysis!.codeQuality).toBe(90);
-      expect(scored.ideaScore).toBe(Math.round(0.6 * 80 + 0.4 * 90));
+      expect(scored.implementationScore).toBe(Math.round(0.6 * 80 + 0.4 * 90));
+      expect(scored.ideaScore).toBe(80); // ideaScore unchanged
 
-      // totalScore = geometric mean: idea^0.65 * readiness^0.35
-      const safeIdea = Math.max(5, scored.ideaScore!);
-      const safeReadiness = Math.max(5, scored.readinessScore!);
-      const expected = Math.round(Math.pow(safeIdea, 0.65) * Math.pow(safeReadiness, 0.35));
-      expect(scored.totalScore).toBe(expected);
+      // totalScore = round(0.7 * 80 + 0.3 * 84) = round(56 + 25.2) = 81
+      expect(scored.totalScore).toBe(Math.round(0.7 * 80 + 0.3 * 84));
     });
 
     it('overrides llmRisk from diff riskAssessment', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = checklistResponse(12, 'low', 'ok');
+      provider.generateTextResponse = dualChecklistResponse(8, 4, 'low', 'ok');
 
       const engine = new ScoringEngine(provider);
       engine.setDiffAnalysis(1, {
@@ -445,7 +445,7 @@ describe('ScoringEngine', () => {
 
     it('does not override risk when diff says medium', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = checklistResponse(12, 'low', 'ok');
+      provider.generateTextResponse = dualChecklistResponse(8, 4, 'low', 'ok');
 
       const engine = new ScoringEngine(provider);
       engine.setDiffAnalysis(1, {
@@ -465,7 +465,7 @@ describe('ScoringEngine', () => {
 
     it('maps critical diff risk to high llmRisk', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = checklistResponse(12, 'low', 'ok');
+      provider.generateTextResponse = dualChecklistResponse(8, 4, 'low', 'ok');
 
       const engine = new ScoringEngine(provider);
       engine.setDiffAnalysis(1, {

--- a/test/integration/scoring-engine.test.ts
+++ b/test/integration/scoring-engine.test.ts
@@ -77,13 +77,12 @@ describe('ScoringEngine', () => {
       expect(provider.generateTextCalls[0].prompt).toContain('feat: add authentication');
     });
 
-    it('should use exact blend formula: 0.4 * heuristic + 0.6 * LLM', async () => {
+    it('should use dual scoring formula: 0.7 * ideaScore + 0.3 * readinessScore', async () => {
       const provider = new MockLLMProvider();
       provider.generateTextResponse = '{"score": 80, "risk": "low", "reason": "Test"}';
 
       const engine = new ScoringEngine(provider);
 
-      // Create a PR that should score exactly 100 heuristically
       const pr = createPRData({
         ciStatus: 'success',
         additions: 200,
@@ -97,14 +96,11 @@ describe('ScoringEngine', () => {
 
       const scored = await engine.score(pr);
 
-      // Calculate expected weighted heuristic score
-      const heuristicScore = scored.signals.reduce((sum, s) => sum + s.score * s.weight, 0) /
-                            scored.signals.reduce((sum, s) => sum + s.weight, 0);
+      // v0.8: totalScore = 0.7 * ideaScore + 0.3 * readinessScore
+      const expected = Math.round(0.7 * scored.ideaScore! + 0.3 * scored.readinessScore!);
 
-      // Expected: 0.4 * heuristic + 0.6 * 80
-      const expected = Math.round(0.4 * heuristicScore + 0.6 * 80);
-
-      expect(scored.llmScore).toBe(80);
+      expect(scored.ideaScore).toBe(80);
+      expect(scored.llmScore).toBe(80); // backward compat
       expect(scored.totalScore).toBe(expected);
     });
 
@@ -145,12 +141,13 @@ describe('ScoringEngine', () => {
       const results = await engine.scoreMany(prs);
 
       expect(results).toHaveLength(3);
-      expect(results[0].number).toBe(1);
-      expect(results[1].number).toBe(2);
-      expect(results[2].number).toBe(3);
+      // v0.8: scoreMany sorts by totalScore for percentile rank
+      const numbers = results.map(r => r.number).sort();
+      expect(numbers).toEqual([1, 2, 3]);
       results.forEach(pr => {
         expect(pr.totalScore).toBeGreaterThan(0);
         expect(pr.signals.length).toBeGreaterThan(0);
+        expect(pr.percentileRank).toBeDefined();
       });
     });
 
@@ -335,13 +332,13 @@ describe('ScoringEngine', () => {
       const engine = new ScoringEngine();
       const pr = createPRData({
         author: 'new-contributor',
-        authorAssociation: 'FIRST_TIME_CONTRIBUTOR', // 40 base score
+        authorAssociation: 'FIRST_TIME_CONTRIBUTOR', // 25 base score (v0.8)
       });
 
       const scored = await engine.score(pr);
 
       const contributorSignal = scored.signals.find(s => s.name === 'contributor');
-      expect(contributorSignal!.score).toBe(40); // No reputation blend
+      expect(contributorSignal!.score).toBe(25); // No reputation blend
       expect(contributorSignal!.reason).not.toContain('rep:');
     });
 
@@ -391,7 +388,7 @@ describe('ScoringEngine', () => {
   });
 
   describe('Diff-enriched scoring blend', () => {
-    it('uses 0.4/0.3/0.3 blend when diff analysis available', async () => {
+    it('blends ideaScore with diff codeQuality when diff analysis available', async () => {
       const provider = new MockLLMProvider();
       provider.generateTextResponse = '{"score": 80, "risk": "low", "reason": "Good PR"}';
 
@@ -408,16 +405,14 @@ describe('ScoringEngine', () => {
       const pr = createPRData({ number: 1, title: 'fix: improve error handling' });
       const scored = await engine.score(pr);
 
-      // With diff: 0.4 * heuristic + 0.3 * 80 + 0.3 * 90
+      // v0.8: ideaScore = 0.6 * LLM + 0.4 * diffQuality = 0.6 * 80 + 0.4 * 90 = 84
       expect(scored.diffAnalysis).toBeDefined();
       expect(scored.diffAnalysis!.codeQuality).toBe(90);
-      expect(scored.totalScore).toBeGreaterThan(0);
+      expect(scored.ideaScore).toBe(Math.round(0.6 * 80 + 0.4 * 90));
 
-      // Verify blend uses diff: totalScore should differ from 0.4*h + 0.6*80
-      const heuristicScore = scored.signals.reduce((sum, s) => sum + s.score * s.weight, 0) /
-                            scored.signals.reduce((sum, s) => sum + s.weight, 0);
-      const expectedWithDiff = Math.round(0.4 * heuristicScore + 0.3 * 80 + 0.3 * 90);
-      expect(scored.totalScore).toBe(expectedWithDiff);
+      // totalScore = 0.7 * ideaScore + 0.3 * readinessScore
+      const expected = Math.round(0.7 * scored.ideaScore! + 0.3 * scored.readinessScore!);
+      expect(scored.totalScore).toBe(expected);
     });
 
     it('overrides llmRisk from diff riskAssessment', async () => {
@@ -520,17 +515,23 @@ describe('ScoringEngine', () => {
 
       const scored = await engine.score(pr);
 
-      const totalWeight = scored.signals.reduce((sum, s) => sum + s.weight, 0);
+      // Filter out intent signal (weight=0 by design in v0.8)
+      const activeSignals = scored.signals.filter(s => s.name !== 'intent');
+      const totalWeight = activeSignals.reduce((sum, s) => sum + s.weight, 0);
 
       // Total weight can exceed 1.0 — signals are normalized by total weight in score()
       expect(totalWeight).toBeGreaterThan(0.9);
       expect(totalWeight).toBeLessThan(2.0);
 
-      // Each signal should have positive weight
-      scored.signals.forEach(s => {
+      // Each active signal should have positive weight
+      activeSignals.forEach(s => {
         expect(s.weight).toBeGreaterThan(0);
         expect(s.weight).toBeLessThanOrEqual(1);
       });
+
+      // Intent signal should have weight 0 (only affects via profiles)
+      const intentSignal = scored.signals.find(s => s.name === 'intent');
+      expect(intentSignal?.weight).toBe(0);
     });
   });
 });

--- a/test/integration/scoring-engine.test.ts
+++ b/test/integration/scoring-engine.test.ts
@@ -51,8 +51,8 @@ describe('ScoringEngine', () => {
   describe('LLM dual scoring', () => {
     it('should produce idea + implementation scores', async () => {
       const provider = new MockLLMProvider();
-      // 7/10 idea → 70, 4/5 impl → 80
-      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Good implementation');
+      // 7*8 + bonus 14 = 70, 4/5 impl → 80
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Good implementation', 14);
 
       const engine = new ScoringEngine(provider);
       const pr = createPRData({
@@ -74,17 +74,18 @@ describe('ScoringEngine', () => {
       // totalScore = 0.7 * idea + 0.3 * implementation
       expect(scored.totalScore).toBe(Math.round(0.7 * 70 + 0.3 * 80));
 
-      // Verify provider was called with dual checklist prompt
+      // Verify provider was called with hybrid checklist prompt
       expect(provider.generateTextCalls.length).toBe(1);
       expect(provider.generateTextCalls[0].prompt).toContain('feat: add authentication');
       expect(provider.generateTextCalls[0].prompt).toContain('PART A');
       expect(provider.generateTextCalls[0].prompt).toContain('PART B');
+      expect(provider.generateTextCalls[0].prompt).toContain('PART C');
     });
 
     it('should use weighted average formula', async () => {
       const provider = new MockLLMProvider();
-      // 8/10 idea → 80, 5/5 impl → 100
-      provider.generateTextResponse = dualChecklistResponse(8, 5, 'low', 'Test');
+      // 8*8 + bonus 16 = 80, 5/5 impl → 100
+      provider.generateTextResponse = dualChecklistResponse(8, 5, 'low', 'Test', 16);
 
       const engine = new ScoringEngine(provider);
       const pr = createPRData({
@@ -162,8 +163,8 @@ describe('ScoringEngine', () => {
 
     it('should process PRs with LLM provider', async () => {
       const provider = new MockLLMProvider();
-      // 7/10 idea → 70, 4/5 impl → 80
-      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Good');
+      // 7*8 + bonus 14 = 70, 4/5 impl → 80
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Good', 14);
 
       const engine = new ScoringEngine(provider);
       const prs = [
@@ -174,7 +175,7 @@ describe('ScoringEngine', () => {
       const results = await engine.scoreMany(prs);
 
       expect(results).toHaveLength(2);
-      expect(results[0].llmScore).toBe(70); // 7/10 * 100
+      expect(results[0].llmScore).toBe(70); // 7*8 + 14
       expect(results[1].llmScore).toBe(70);
       expect(provider.generateTextCalls.length).toBe(2);
     });
@@ -397,8 +398,8 @@ describe('ScoringEngine', () => {
   describe('Diff-enriched scoring blend', () => {
     it('blends implementationScore with diff codeQuality when diff analysis available', async () => {
       const provider = new MockLLMProvider();
-      // 8/10 idea → 80, 4/5 impl → 80
-      provider.generateTextResponse = dualChecklistResponse(8, 4, 'low', 'Good PR');
+      // 8*8 + bonus 16 = 80, 4/5 impl → 80
+      provider.generateTextResponse = dualChecklistResponse(8, 4, 'low', 'Good PR', 16);
 
       const engine = new ScoringEngine(provider);
       engine.setDiffAnalysis(1, {
@@ -540,6 +541,107 @@ describe('ScoringEngine', () => {
       // Intent signal should have weight 0 (only affects via profiles)
       const intentSignal = scored.signals.find(s => s.name === 'intent');
       expect(intentSignal?.weight).toBe(0);
+    });
+  });
+
+  describe('Cascade integration', () => {
+    it('cascade reduces LLM calls for mixed-quality batch', async () => {
+      const haiku = new MockLLMProvider();
+      const sonnet = new MockLLMProvider();
+
+      // Haiku response varies per call: low score for junk, high for quality
+      let haikuCallCount = 0;
+      haiku.generateTextResponse = (prompt: string) => {
+        haikuCallCount++;
+        // Quality PRs get high scores, junk gets low
+        if (prompt.includes('Quality PR')) {
+          return dualChecklistResponse(7, 4, 'low', 'Good PR', 12); // 68 >= 40
+        }
+        return dualChecklistResponse(1, 1, 'low', 'Junk', 2); // 10 < 40
+      };
+      sonnet.generateTextResponse = dualChecklistResponse(6, 3, 'medium', 'Sonnet refined', 10);
+
+      const engine = new ScoringEngine({
+        provider: haiku,
+        cascade: { enabled: true, reScoreProvider: sonnet, haikuThreshold: 40 },
+      });
+
+      const prs = [
+        createPRData({ number: 1, title: 'Quality PR: auth system', ciStatus: 'success' }),
+        createPRData({
+          number: 2, title: 'fix typo', body: 'x',
+          additions: 1, deletions: 0, hasIssueRef: false, hasTests: false,
+          changedFiles: ['README.md'], authorAssociation: 'NONE',
+        }),
+        createPRData({ number: 3, title: 'Quality PR: security fix', ciStatus: 'success' }),
+      ];
+
+      const results = await engine.scoreMany(prs);
+      expect(results.length).toBe(3);
+
+      // PR #2 is spam → pre-filtered, no LLM calls
+      const spamPR = results.find(r => r.number === 2);
+      expect(spamPR?.scoredBy).toBe('heuristic');
+
+      // Quality PRs → Haiku + Sonnet
+      const qualityPRs = results.filter(r => r.number !== 2);
+      for (const pr of qualityPRs) {
+        expect(pr.scoredBy).toBe('sonnet');
+      }
+
+      // Sonnet only called for quality PRs (2 calls), not for spam
+      expect(sonnet.generateTextCalls.length).toBe(2);
+    });
+
+    it('Sonnet prompt identical to Haiku prompt', async () => {
+      const haiku = new MockLLMProvider();
+      const sonnet = new MockLLMProvider();
+      // Haiku above threshold → triggers Sonnet
+      haiku.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Above threshold', 12);
+      sonnet.generateTextResponse = dualChecklistResponse(6, 3, 'low', 'Sonnet', 10);
+
+      const engine = new ScoringEngine({
+        provider: haiku,
+        cascade: { enabled: true, reScoreProvider: sonnet, haikuThreshold: 40 },
+      });
+
+      const pr = createPRData({ title: 'feat: new auth module' });
+      await engine.score(pr);
+
+      expect(haiku.generateTextCalls.length).toBe(1);
+      expect(sonnet.generateTextCalls.length).toBe(1);
+      // Both should receive the exact same prompt
+      expect(sonnet.generateTextCalls[0].prompt).toBe(haiku.generateTextCalls[0].prompt);
+    });
+
+    it('cascade with options-based constructor preserves all settings', async () => {
+      const haiku = new MockLLMProvider();
+      const sonnet = new MockLLMProvider();
+      haiku.generateTextResponse = dualChecklistResponse(3, 2, 'low', 'Below threshold', 4);
+
+      const engine = new ScoringEngine({
+        provider: haiku,
+        trustContributors: true,
+        maxConcurrent: 3,
+        cascade: {
+          enabled: true,
+          reScoreProvider: sonnet,
+          preFilterThreshold: 10,
+          haikuThreshold: 50,
+        },
+      });
+
+      const pr = createPRData({ authorAssociation: 'CONTRIBUTOR' });
+      const scored = await engine.score(pr);
+
+      // haiku ideaScore = 3*8+4 = 28 < 50 threshold → stays as haiku
+      expect(scored.scoredBy).toBe('haiku');
+      expect(scored.ideaScore).toBe(28);
+      expect(sonnet.generateTextCalls.length).toBe(0);
+
+      // Verify trustContributors works
+      const spamSignal = scored.signals.find(s => s.name === 'spam');
+      expect(spamSignal?.reason).toContain('Trusted contributor');
     });
   });
 });

--- a/test/integration/scoring-engine.test.ts
+++ b/test/integration/scoring-engine.test.ts
@@ -4,7 +4,7 @@
 
 import { ScoringEngine } from '../../src/core/scoring';
 import { createPRData } from '../fixtures/pr-factory';
-import { MockLLMProvider } from '../fixtures/mock-provider';
+import { MockLLMProvider, checklistResponse } from '../fixtures/mock-provider';
 
 describe('ScoringEngine', () => {
   describe('Heuristic-only scoring (no LLM)', () => {
@@ -51,7 +51,8 @@ describe('ScoringEngine', () => {
   describe('LLM blend scoring', () => {
     it('should blend heuristic and LLM scores', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 75, "risk": "low", "reason": "Good implementation"}';
+      // 11 yes → ideaScore=73
+      provider.generateTextResponse = checklistResponse(11, 'low', 'Good implementation');
 
       const engine = new ScoringEngine(provider);
       const pr = createPRData({
@@ -64,22 +65,23 @@ describe('ScoringEngine', () => {
 
       const scored = await engine.score(pr);
 
-      expect(scored.llmScore).toBe(75);
+      expect(scored.llmScore).toBe(73);
       expect(scored.llmRisk).toBe('low');
       expect(scored.llmReason).toBe('Good implementation');
 
-      // totalScore = 0.4 * heuristic + 0.6 * 75
+      // totalScore = geometric mean of ideaScore and readinessScore
       expect(scored.totalScore).toBeGreaterThan(0);
       expect(scored.totalScore).toBeLessThanOrEqual(100);
 
-      // Verify provider was called
+      // Verify provider was called with checklist prompt
       expect(provider.generateTextCalls.length).toBe(1);
       expect(provider.generateTextCalls[0].prompt).toContain('feat: add authentication');
     });
 
-    it('should use dual scoring formula: 0.7 * ideaScore + 0.3 * readinessScore', async () => {
+    it('should use weighted geometric mean formula', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 80, "risk": "low", "reason": "Test"}';
+      // 12 yes → ideaScore=80
+      provider.generateTextResponse = checklistResponse(12, 'low', 'Test');
 
       const engine = new ScoringEngine(provider);
 
@@ -96,8 +98,10 @@ describe('ScoringEngine', () => {
 
       const scored = await engine.score(pr);
 
-      // v0.8: totalScore = 0.7 * ideaScore + 0.3 * readinessScore
-      const expected = Math.round(0.7 * scored.ideaScore! + 0.3 * scored.readinessScore!);
+      // v0.8: totalScore = idea^0.65 * readiness^0.35 (geometric mean)
+      const safeIdea = Math.max(5, scored.ideaScore!);
+      const safeReadiness = Math.max(5, scored.readinessScore!);
+      const expected = Math.round(Math.pow(safeIdea, 0.65) * Math.pow(safeReadiness, 0.35));
 
       expect(scored.ideaScore).toBe(80);
       expect(scored.llmScore).toBe(80); // backward compat
@@ -108,21 +112,21 @@ describe('ScoringEngine', () => {
       const provider = new MockLLMProvider();
 
       // Test low risk
-      provider.generateTextResponse = '{"score": 90, "risk": "low", "reason": "Safe change"}';
+      provider.generateTextResponse = checklistResponse(14, 'low', 'Safe change');
       let engine = new ScoringEngine(provider);
       let scored = await engine.score(createPRData());
       expect(scored.llmRisk).toBe('low');
 
       // Test medium risk
       provider.reset();
-      provider.generateTextResponse = '{"score": 60, "risk": "medium", "reason": "Some concerns"}';
+      provider.generateTextResponse = checklistResponse(9, 'medium', 'Some concerns');
       engine = new ScoringEngine(provider);
       scored = await engine.score(createPRData());
       expect(scored.llmRisk).toBe('medium');
 
       // Test high risk
       provider.reset();
-      provider.generateTextResponse = '{"score": 30, "risk": "high", "reason": "Breaking changes"}';
+      provider.generateTextResponse = checklistResponse(5, 'high', 'Breaking changes');
       engine = new ScoringEngine(provider);
       scored = await engine.score(createPRData());
       expect(scored.llmRisk).toBe('high');
@@ -159,7 +163,8 @@ describe('ScoringEngine', () => {
 
     it('should process PRs with LLM provider', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 75, "risk": "low", "reason": "Good"}';
+      // 11 yes → ideaScore=73
+      provider.generateTextResponse = checklistResponse(11, 'low', 'Good');
 
       const engine = new ScoringEngine(provider);
       const prs = [
@@ -170,8 +175,8 @@ describe('ScoringEngine', () => {
       const results = await engine.scoreMany(prs);
 
       expect(results).toHaveLength(2);
-      expect(results[0].llmScore).toBe(75);
-      expect(results[1].llmScore).toBe(75);
+      expect(results[0].llmScore).toBe(73); // 11/15 * 100
+      expect(results[1].llmScore).toBe(73);
       expect(provider.generateTextCalls.length).toBe(2);
     });
   });
@@ -390,7 +395,8 @@ describe('ScoringEngine', () => {
   describe('Diff-enriched scoring blend', () => {
     it('blends ideaScore with diff codeQuality when diff analysis available', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 80, "risk": "low", "reason": "Good PR"}';
+      // 12 yes → base ideaScore=80
+      provider.generateTextResponse = checklistResponse(12, 'low', 'Good PR');
 
       const engine = new ScoringEngine(provider);
       engine.setDiffAnalysis(1, {
@@ -405,19 +411,21 @@ describe('ScoringEngine', () => {
       const pr = createPRData({ number: 1, title: 'fix: improve error handling' });
       const scored = await engine.score(pr);
 
-      // v0.8: ideaScore = 0.6 * LLM + 0.4 * diffQuality = 0.6 * 80 + 0.4 * 90 = 84
+      // v0.8: ideaScore = 0.6 * checklist + 0.4 * diffQuality = 0.6 * 80 + 0.4 * 90 = 84
       expect(scored.diffAnalysis).toBeDefined();
       expect(scored.diffAnalysis!.codeQuality).toBe(90);
       expect(scored.ideaScore).toBe(Math.round(0.6 * 80 + 0.4 * 90));
 
-      // totalScore = 0.7 * ideaScore + 0.3 * readinessScore
-      const expected = Math.round(0.7 * scored.ideaScore! + 0.3 * scored.readinessScore!);
+      // totalScore = geometric mean: idea^0.65 * readiness^0.35
+      const safeIdea = Math.max(5, scored.ideaScore!);
+      const safeReadiness = Math.max(5, scored.readinessScore!);
+      const expected = Math.round(Math.pow(safeIdea, 0.65) * Math.pow(safeReadiness, 0.35));
       expect(scored.totalScore).toBe(expected);
     });
 
     it('overrides llmRisk from diff riskAssessment', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 80, "risk": "low", "reason": "ok"}';
+      provider.generateTextResponse = checklistResponse(12, 'low', 'ok');
 
       const engine = new ScoringEngine(provider);
       engine.setDiffAnalysis(1, {
@@ -437,7 +445,7 @@ describe('ScoringEngine', () => {
 
     it('does not override risk when diff says medium', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 80, "risk": "low", "reason": "ok"}';
+      provider.generateTextResponse = checklistResponse(12, 'low', 'ok');
 
       const engine = new ScoringEngine(provider);
       engine.setDiffAnalysis(1, {
@@ -457,7 +465,7 @@ describe('ScoringEngine', () => {
 
     it('maps critical diff risk to high llmRisk', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 80, "risk": "low", "reason": "ok"}';
+      provider.generateTextResponse = checklistResponse(12, 'low', 'ok');
 
       const engine = new ScoringEngine(provider);
       engine.setDiffAnalysis(1, {

--- a/test/unit/intent-profiles.test.ts
+++ b/test/unit/intent-profiles.test.ts
@@ -2,12 +2,13 @@ import { ScoringEngine } from '../../src/core/scoring';
 import { createPRData } from '../fixtures/pr-factory';
 
 describe('Intent-Aware Scoring Profiles', () => {
-  it('uses intent weight of 0.15', async () => {
+  it('intent signal has weight 0 (disabled in v0.8, only affects via profiles)', async () => {
     const engine = new ScoringEngine();
     const pr = createPRData({ title: 'feat: add feature' });
     const scored = await engine.score(pr);
     const signal = scored.signals.find(s => s.name === 'intent');
-    expect(signal?.weight).toBeGreaterThan(0);
+    expect(signal?.weight).toBe(0);
+    expect(signal?.score).toBe(0);
   });
 
   it('applies bugfix profile: higher ci_status weight', async () => {

--- a/test/unit/retryable-provider.test.ts
+++ b/test/unit/retryable-provider.test.ts
@@ -1,5 +1,5 @@
 import { RetryableProvider } from '../../src/core/retryable-provider';
-import { MockLLMProvider } from '../fixtures/mock-provider';
+import { MockLLMProvider, checklistResponse } from '../fixtures/mock-provider';
 
 describe('RetryableProvider', () => {
   let mock: MockLLMProvider;
@@ -20,7 +20,7 @@ describe('RetryableProvider', () => {
   it('delegates generateText to inner provider', async () => {
     const provider = new RetryableProvider(mock);
     const result = await provider.generateText('hello');
-    expect(result).toBe('{"score": 75, "risk": "low", "reason": "Mock LLM response"}');
+    expect(result).toBe(checklistResponse(11, 'low', 'Mock LLM response'));
     expect(mock.generateTextCalls).toHaveLength(1);
   });
 

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -4,7 +4,7 @@
 
 import { ScoringEngine } from '../../src/core/scoring';
 import { createPRData } from '../fixtures/pr-factory';
-import { MockLLMProvider } from '../fixtures/mock-provider';
+import { MockLLMProvider, checklistResponse } from '../fixtures/mock-provider';
 
 describe('ScoringEngine', () => {
   describe('ci_status signal', () => {
@@ -608,7 +608,8 @@ describe('ScoringEngine', () => {
   describe('tier classification', () => {
     it('assigns critical when ideaScore>=80 and readiness>=60', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 85, "risk": "low", "reason": "Critical fix"}';
+      // 13 yes → ideaScore=87
+      provider.generateTextResponse = checklistResponse(13, 'low', 'Critical fix');
       const engine = new ScoringEngine(provider);
       const pr = createPRData(); // good defaults = high readiness
       const scored = await engine.score(pr);
@@ -618,7 +619,8 @@ describe('ScoringEngine', () => {
 
     it('assigns high when ideaScore>=70 but readiness<60', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 80, "risk": "low", "reason": "Good idea"}';
+      // 11 yes → ideaScore=73
+      provider.generateTextResponse = checklistResponse(11, 'low', 'Good idea');
       const engine = new ScoringEngine(provider);
       // Draft PR = low readiness due to 0.4x penalty
       const pr = createPRData({ isDraft: true });
@@ -629,7 +631,8 @@ describe('ScoringEngine', () => {
 
     it('assigns normal when ideaScore 45-69', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 55, "risk": "low", "reason": "Routine fix"}';
+      // 8 yes → ideaScore=53
+      provider.generateTextResponse = checklistResponse(8, 'low', 'Routine fix');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -638,7 +641,8 @@ describe('ScoringEngine', () => {
 
     it('assigns low when ideaScore<45', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 20, "risk": "low", "reason": "Trivial"}';
+      // 3 yes → ideaScore=20
+      provider.generateTextResponse = checklistResponse(3, 'low', 'Trivial');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -655,28 +659,36 @@ describe('ScoringEngine', () => {
   });
 
   describe('dual scoring — LLM integration', () => {
-    it('returns ideaScore from LLM', async () => {
+    it('returns ideaScore from CheckEval checklist', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 75, "risk": "low", "reason": "Test"}';
+      // 11 yes → ideaScore = Math.round(11/15 * 100) = 73
+      provider.generateTextResponse = checklistResponse(11, 'low', 'Test');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
 
-      expect(scored.ideaScore).toBe(75);
+      expect(scored.ideaScore).toBe(73);
       expect(scored.ideaReason).toBe('Test');
+      expect(scored.ideaChecklist).toBeDefined();
+      expect(scored.ideaChecklist).toHaveLength(15);
+      expect(scored.ideaChecklist!.filter(a => a).length).toBe(11);
       // backward compat
-      expect(scored.llmScore).toBe(75);
+      expect(scored.llmScore).toBe(73);
       expect(scored.llmRisk).toBe('low');
     });
 
-    it('computes totalScore = 0.7 * ideaScore + 0.3 * readinessScore', async () => {
+    it('computes totalScore with weighted geometric mean', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = '{"score": 75, "risk": "low", "reason": "Test"}';
+      // 11 yes → ideaScore=73
+      provider.generateTextResponse = checklistResponse(11, 'low', 'Test');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
 
-      const expected = Math.round(0.7 * scored.ideaScore! + 0.3 * scored.readinessScore!);
+      // Geometric mean: idea^0.65 * readiness^0.35 (floor=5)
+      const safeIdea = Math.max(5, scored.ideaScore!);
+      const safeReadiness = Math.max(5, scored.readinessScore!);
+      const expected = Math.round(Math.pow(safeIdea, 0.65) * Math.pow(safeReadiness, 0.35));
       expect(scored.totalScore).toBe(expected);
     });
 

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -606,7 +606,7 @@ describe('ScoringEngine', () => {
   });
 
   describe('tier classification', () => {
-    it('assigns critical when ideaScore>=80 and readiness>=60', async () => {
+    it('assigns critical when ideaScore>=80 and readiness>=55', async () => {
       const provider = new MockLLMProvider();
       // 13 yes → ideaScore=87
       provider.generateTextResponse = checklistResponse(13, 'low', 'Critical fix');
@@ -617,7 +617,7 @@ describe('ScoringEngine', () => {
       expect(scored.tier).toBe('critical');
     });
 
-    it('assigns high when ideaScore>=70 but readiness<60', async () => {
+    it('assigns high when ideaScore>=67 (10/15) but readiness<55', async () => {
       const provider = new MockLLMProvider();
       // 11 yes → ideaScore=73
       provider.generateTextResponse = checklistResponse(11, 'low', 'Good idea');
@@ -625,11 +625,22 @@ describe('ScoringEngine', () => {
       // Draft PR = low readiness due to 0.4x penalty
       const pr = createPRData({ isDraft: true });
       const scored = await engine.score(pr);
-      // Draft penalty drops readiness below 60
+      // Draft penalty drops readiness below 55
       expect(scored.tier).toBe('high');
     });
 
-    it('assigns normal when ideaScore 45-69', async () => {
+    it('assigns high for exactly 10/15 (ideaScore=67)', async () => {
+      const provider = new MockLLMProvider();
+      // 10 yes → ideaScore=67
+      provider.generateTextResponse = checklistResponse(10, 'low', 'Security fix');
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.ideaScore).toBe(67);
+      expect(scored.tier).toBe('high');
+    });
+
+    it('assigns normal when ideaScore 40-66', async () => {
       const provider = new MockLLMProvider();
       // 8 yes → ideaScore=53
       provider.generateTextResponse = checklistResponse(8, 'low', 'Routine fix');
@@ -639,7 +650,7 @@ describe('ScoringEngine', () => {
       expect(scored.tier).toBe('normal');
     });
 
-    it('assigns low when ideaScore<45', async () => {
+    it('assigns low when ideaScore<40', async () => {
       const provider = new MockLLMProvider();
       // 3 yes → ideaScore=20
       provider.generateTextResponse = checklistResponse(3, 'low', 'Trivial');

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -1,10 +1,10 @@
 /**
- * Unit tests for ScoringEngine — v0.8 dual scoring
+ * Unit tests for ScoringEngine — v0.8 dual scoring (idea + implementation)
  */
 
 import { ScoringEngine } from '../../src/core/scoring';
 import { createPRData } from '../fixtures/pr-factory';
-import { MockLLMProvider, checklistResponse } from '../fixtures/mock-provider';
+import { MockLLMProvider, dualChecklistResponse } from '../fixtures/mock-provider';
 
 describe('ScoringEngine', () => {
   describe('ci_status signal', () => {
@@ -128,11 +128,9 @@ describe('ScoringEngine', () => {
 
     it('has base weight 0.04 (before intent normalization)', async () => {
       const engine = new ScoringEngine();
-      // Use a title without conventional prefix to avoid intent profile overrides
       const pr = createPRData({ title: 'Update something', changedFiles: ['src/main.ts'] });
       const scored = await engine.score(pr);
       const signal = scored.signals.find(s => s.name === 'contributor');
-      // After normalization weights may shift, but contributor should be low relative to others
       expect(signal?.weight).toBeLessThan(0.1);
     });
   });
@@ -533,7 +531,6 @@ describe('ScoringEngine', () => {
         milestone: undefined,
       });
       const scored = await engine.score(pr);
-      // CI failure (0.4x) + conflict (0.5x) + draft (0.4x) = very low
       expect(scored.readinessScore!).toBeLessThan(15);
     });
   });
@@ -576,11 +573,9 @@ describe('ScoringEngine', () => {
         authorAssociation: 'NONE',
       });
       const scored = await engine.score(pr);
-      // If spam detected: 0.4 * 0.2 * 0.4 = 0.032
       if (scored.isSpam) {
         expect(scored.readinessScore!).toBeLessThan(10);
       } else {
-        // Even without spam: 0.4 * 0.4 = 0.16
         expect(scored.readinessScore!).toBeLessThan(20);
       }
     });
@@ -606,57 +601,57 @@ describe('ScoringEngine', () => {
   });
 
   describe('tier classification', () => {
-    it('assigns critical when ideaScore>=80 and readiness>=55', async () => {
+    it('assigns critical when ideaScore>=80', async () => {
       const provider = new MockLLMProvider();
-      // 13 yes → ideaScore=87
-      provider.generateTextResponse = checklistResponse(13, 'low', 'Critical fix');
+      // 8/10 idea → ideaScore=80, 5/5 impl → implScore=100
+      provider.generateTextResponse = dualChecklistResponse(8, 5, 'low', 'Critical fix');
       const engine = new ScoringEngine(provider);
-      const pr = createPRData(); // good defaults = high readiness
+      const pr = createPRData();
       const scored = await engine.score(pr);
-      expect(scored.ideaScore).toBeGreaterThanOrEqual(80);
+      expect(scored.ideaScore).toBe(80);
       expect(scored.tier).toBe('critical');
     });
 
-    it('assigns high when ideaScore>=67 (10/15) but readiness<55', async () => {
+    it('assigns high when ideaScore>=60', async () => {
       const provider = new MockLLMProvider();
-      // 11 yes → ideaScore=73
-      provider.generateTextResponse = checklistResponse(11, 'low', 'Good idea');
-      const engine = new ScoringEngine(provider);
-      // Draft PR = low readiness due to 0.4x penalty
-      const pr = createPRData({ isDraft: true });
-      const scored = await engine.score(pr);
-      // Draft penalty drops readiness below 55
-      expect(scored.tier).toBe('high');
-    });
-
-    it('assigns high for exactly 10/15 (ideaScore=67)', async () => {
-      const provider = new MockLLMProvider();
-      // 10 yes → ideaScore=67
-      provider.generateTextResponse = checklistResponse(10, 'low', 'Security fix');
+      // 7/10 idea → ideaScore=70
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Good idea');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
-      expect(scored.ideaScore).toBe(67);
+      expect(scored.ideaScore).toBe(70);
       expect(scored.tier).toBe('high');
     });
 
-    it('assigns normal when ideaScore 40-66', async () => {
+    it('assigns high for exactly 6/10 (ideaScore=60)', async () => {
       const provider = new MockLLMProvider();
-      // 8 yes → ideaScore=53
-      provider.generateTextResponse = checklistResponse(8, 'low', 'Routine fix');
+      provider.generateTextResponse = dualChecklistResponse(6, 3, 'low', 'Decent fix');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
+      expect(scored.ideaScore).toBe(60);
+      expect(scored.tier).toBe('high');
+    });
+
+    it('assigns normal when ideaScore 30-59', async () => {
+      const provider = new MockLLMProvider();
+      // 5/10 idea → ideaScore=50
+      provider.generateTextResponse = dualChecklistResponse(5, 3, 'low', 'Routine fix');
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.ideaScore).toBe(50);
       expect(scored.tier).toBe('normal');
     });
 
-    it('assigns low when ideaScore<40', async () => {
+    it('assigns low when ideaScore<30', async () => {
       const provider = new MockLLMProvider();
-      // 3 yes → ideaScore=20
-      provider.generateTextResponse = checklistResponse(3, 'low', 'Trivial');
+      // 2/10 idea → ideaScore=20
+      provider.generateTextResponse = dualChecklistResponse(2, 1, 'low', 'Trivial');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
+      expect(scored.ideaScore).toBe(20);
       expect(scored.tier).toBe('low');
     });
 
@@ -669,38 +664,63 @@ describe('ScoringEngine', () => {
     });
   });
 
-  describe('dual scoring — LLM integration', () => {
-    it('returns ideaScore from CheckEval checklist', async () => {
+  describe('dual scoring — idea + implementation', () => {
+    it('returns separate ideaScore and implementationScore', async () => {
       const provider = new MockLLMProvider();
-      // 11 yes → ideaScore = Math.round(11/15 * 100) = 73
-      provider.generateTextResponse = checklistResponse(11, 'low', 'Test');
+      // 7/10 idea → 70, 4/5 impl → 80
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Test');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
 
-      expect(scored.ideaScore).toBe(73);
+      expect(scored.ideaScore).toBe(70);
+      expect(scored.implementationScore).toBe(80);
       expect(scored.ideaReason).toBe('Test');
-      expect(scored.ideaChecklist).toBeDefined();
-      expect(scored.ideaChecklist).toHaveLength(15);
-      expect(scored.ideaChecklist!.filter(a => a).length).toBe(11);
+      expect(scored.ideaChecklist).toHaveLength(10);
+      expect(scored.implementationChecklist).toHaveLength(5);
+      expect(scored.ideaChecklist!.filter(a => a).length).toBe(7);
+      expect(scored.implementationChecklist!.filter(a => a).length).toBe(4);
       // backward compat
-      expect(scored.llmScore).toBe(73);
+      expect(scored.llmScore).toBe(70);
       expect(scored.llmRisk).toBe('low');
     });
 
-    it('computes totalScore with weighted geometric mean', async () => {
+    it('computes totalScore as 0.7*idea + 0.3*implementation', async () => {
       const provider = new MockLLMProvider();
-      // 11 yes → ideaScore=73
-      provider.generateTextResponse = checklistResponse(11, 'low', 'Test');
+      // 7/10 idea → 70, 4/5 impl → 80
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Test');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
 
-      // Geometric mean: idea^0.65 * readiness^0.35 (floor=5)
-      const safeIdea = Math.max(5, scored.ideaScore!);
-      const safeReadiness = Math.max(5, scored.readinessScore!);
-      const expected = Math.round(Math.pow(safeIdea, 0.65) * Math.pow(safeReadiness, 0.35));
-      expect(scored.totalScore).toBe(expected);
+      // totalScore = round(0.7 * 70 + 0.3 * 80) = round(49 + 24) = 73
+      expect(scored.totalScore).toBe(73);
+    });
+
+    it('high idea + low implementation = idea-driven total', async () => {
+      const provider = new MockLLMProvider();
+      // 8/10 idea → 80, 1/5 impl → 20
+      provider.generateTextResponse = dualChecklistResponse(8, 1, 'medium', 'Great idea, bad code');
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+
+      // totalScore = round(0.7 * 80 + 0.3 * 20) = round(56 + 6) = 62
+      expect(scored.totalScore).toBe(62);
+      expect(scored.ideaScore).toBe(80);
+      expect(scored.implementationScore).toBe(20);
+    });
+
+    it('low idea + high implementation = still low total', async () => {
+      const provider = new MockLLMProvider();
+      // 1/10 idea → 10, 5/5 impl → 100
+      provider.generateTextResponse = dualChecklistResponse(1, 5, 'low', 'Trivial but polished');
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+
+      // totalScore = round(0.7 * 10 + 0.3 * 100) = round(7 + 30) = 37
+      expect(scored.totalScore).toBe(37);
     });
 
     it('uses readinessScore as totalScore when no provider', async () => {
@@ -710,7 +730,7 @@ describe('ScoringEngine', () => {
 
       expect(scored.totalScore).toBe(scored.readinessScore);
       expect(scored.ideaScore).toBeUndefined();
-      expect(scored.llmScore).toBeUndefined();
+      expect(scored.implementationScore).toBeUndefined();
     });
   });
 
@@ -724,13 +744,11 @@ describe('ScoringEngine', () => {
       ];
       const scored = await engine.scoreMany(prs);
       expect(scored.length).toBe(3);
-      // All should have percentileRank
       for (const s of scored) {
         expect(s.percentileRank).toBeDefined();
         expect(s.percentileRank).toBeGreaterThanOrEqual(0);
         expect(s.percentileRank).toBeLessThanOrEqual(100);
       }
-      // Lowest score should have percentileRank=0, highest=100
       expect(scored[0].percentileRank).toBe(0);
       expect(scored[scored.length - 1].percentileRank).toBe(100);
     });
@@ -746,25 +764,24 @@ describe('ScoringEngine', () => {
   describe('issue context enrichment', () => {
     it('includes issueContext in LLM prompt when available', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = checklistResponse(11, 'low', 'With context');
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'With context');
       const engine = new ScoringEngine(provider);
       const pr = createPRData({
         issueContext: 'Bug: login crashes when password contains special chars',
       });
       const scored = await engine.score(pr);
-      expect(scored.ideaScore).toBe(73);
-      // Verify the prompt contained the issue context
+      expect(scored.ideaScore).toBe(70);
       expect(provider.generateTextCalls.length).toBe(1);
       expect(provider.generateTextCalls[0].prompt).toContain('login crashes when password');
     });
 
     it('works without issueContext', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = checklistResponse(10, 'low', 'No context');
+      provider.generateTextResponse = dualChecklistResponse(6, 3, 'low', 'No context');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
-      expect(scored.ideaScore).toBe(67);
+      expect(scored.ideaScore).toBe(60);
       expect(provider.generateTextCalls[0].prompt).not.toContain('Linked issue:');
     });
   });
@@ -772,7 +789,7 @@ describe('ScoringEngine', () => {
   describe('median-of-N scoring passes', () => {
     it('uses single pass by default', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = checklistResponse(10, 'low', 'Single');
+      provider.generateTextResponse = dualChecklistResponse(6, 3, 'low', 'Single');
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       await engine.score(pr);
@@ -784,26 +801,24 @@ describe('ScoringEngine', () => {
       let callCount = 0;
       provider.generateTextResponse = () => {
         callCount++;
-        // Return different scores: 8, 10, 12 yes
-        const yesCount = [8, 12, 10][callCount - 1] ?? 10;
-        return checklistResponse(yesCount, 'low', `Pass ${callCount}`);
+        // Return different idea scores: 5/10=50, 8/10=80, 7/10=70
+        const ideaYes = [5, 8, 7][callCount - 1] ?? 7;
+        return dualChecklistResponse(ideaYes, 4, 'low', `Pass ${callCount}`);
       };
       const engine = new ScoringEngine(provider, false, 5, 3);
       const pr = createPRData();
       const scored = await engine.score(pr);
-      // Should make 3 LLM calls
       expect(provider.generateTextCalls.length).toBe(3);
-      // Median of [53, 67, 80] sorted = 67 (10/15)
-      expect(scored.ideaScore).toBe(67);
+      // Sorted by ideaScore: [50, 70, 80] → median = 70 (7/10)
+      expect(scored.ideaScore).toBe(70);
     });
 
     it('enforces minimum 1 pass', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = checklistResponse(11, 'low', 'Min pass');
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Min pass');
       const engine = new ScoringEngine(provider, false, 5, 0);
       const pr = createPRData();
       await engine.score(pr);
-      // Should still make 1 call even with 0 passes
       expect(provider.generateTextCalls.length).toBe(1);
     });
   });

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -743,6 +743,71 @@ describe('ScoringEngine', () => {
     });
   });
 
+  describe('issue context enrichment', () => {
+    it('includes issueContext in LLM prompt when available', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = checklistResponse(11, 'low', 'With context');
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData({
+        issueContext: 'Bug: login crashes when password contains special chars',
+      });
+      const scored = await engine.score(pr);
+      expect(scored.ideaScore).toBe(73);
+      // Verify the prompt contained the issue context
+      expect(provider.generateTextCalls.length).toBe(1);
+      expect(provider.generateTextCalls[0].prompt).toContain('login crashes when password');
+    });
+
+    it('works without issueContext', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = checklistResponse(10, 'low', 'No context');
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.ideaScore).toBe(67);
+      expect(provider.generateTextCalls[0].prompt).not.toContain('Linked issue:');
+    });
+  });
+
+  describe('median-of-N scoring passes', () => {
+    it('uses single pass by default', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = checklistResponse(10, 'low', 'Single');
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      await engine.score(pr);
+      expect(provider.generateTextCalls.length).toBe(1);
+    });
+
+    it('runs N passes and takes median when scoringPasses > 1', async () => {
+      const provider = new MockLLMProvider();
+      let callCount = 0;
+      provider.generateTextResponse = () => {
+        callCount++;
+        // Return different scores: 8, 10, 12 yes
+        const yesCount = [8, 12, 10][callCount - 1] ?? 10;
+        return checklistResponse(yesCount, 'low', `Pass ${callCount}`);
+      };
+      const engine = new ScoringEngine(provider, false, 5, 3);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      // Should make 3 LLM calls
+      expect(provider.generateTextCalls.length).toBe(3);
+      // Median of [53, 67, 80] sorted = 67 (10/15)
+      expect(scored.ideaScore).toBe(67);
+    });
+
+    it('enforces minimum 1 pass', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = checklistResponse(11, 'low', 'Min pass');
+      const engine = new ScoringEngine(provider, false, 5, 0);
+      const pr = createPRData();
+      await engine.score(pr);
+      // Should still make 1 call even with 0 passes
+      expect(provider.generateTextCalls.length).toBe(1);
+    });
+  });
+
   describe('spam detection', () => {
     it('marks PR as spam when spam score < 25', async () => {
       const engine = new ScoringEngine();

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -1,5 +1,5 @@
 /**
- * Unit tests for ScoringEngine
+ * Unit tests for ScoringEngine — v0.8 dual scoring
  */
 
 import { ScoringEngine } from '../../src/core/scoring';
@@ -32,12 +32,12 @@ describe('ScoringEngine', () => {
       expect(signal?.score).toBe(10);
     });
 
-    it('scores unknown as 40', async () => {
+    it('scores unknown as 0', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData({ ciStatus: 'unknown' });
       const scored = await engine.score(pr);
       const signal = scored.signals.find(s => s.name === 'ci_status');
-      expect(signal?.score).toBe(40);
+      expect(signal?.score).toBe(0);
     });
   });
 
@@ -110,12 +110,30 @@ describe('ScoringEngine', () => {
       expect(signal?.score).toBe(100);
     });
 
-    it('scores NONE as 30', async () => {
+    it('scores NONE as 15', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData({ authorAssociation: 'NONE' });
       const scored = await engine.score(pr);
       const signal = scored.signals.find(s => s.name === 'contributor');
-      expect(signal?.score).toBe(30);
+      expect(signal?.score).toBe(15);
+    });
+
+    it('scores FIRST_TIMER as 25', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData({ authorAssociation: 'FIRST_TIMER' });
+      const scored = await engine.score(pr);
+      const signal = scored.signals.find(s => s.name === 'contributor');
+      expect(signal?.score).toBe(25);
+    });
+
+    it('has base weight 0.04 (before intent normalization)', async () => {
+      const engine = new ScoringEngine();
+      // Use a title without conventional prefix to avoid intent profile overrides
+      const pr = createPRData({ title: 'Update something', changedFiles: ['src/main.ts'] });
+      const scored = await engine.score(pr);
+      const signal = scored.signals.find(s => s.name === 'contributor');
+      // After normalization weights may shift, but contributor should be low relative to others
+      expect(signal?.weight).toBeLessThan(0.1);
     });
   });
 
@@ -128,12 +146,12 @@ describe('ScoringEngine', () => {
       expect(signal?.score).toBe(90);
     });
 
-    it('scores without issue reference as 30', async () => {
+    it('scores without issue reference as 0', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData({ hasIssueRef: false, issueNumbers: [] });
       const scored = await engine.score(pr);
       const signal = scored.signals.find(s => s.name === 'issue_ref');
-      expect(signal?.score).toBe(30);
+      expect(signal?.score).toBe(0);
     });
   });
 
@@ -270,6 +288,14 @@ describe('ScoringEngine', () => {
       const signal = scored.signals.find(s => s.name === 'review_status');
       expect(signal?.score).toBe(30);
     });
+
+    it('scores none as 0', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData({ reviewState: 'none', reviewCount: 0 });
+      const scored = await engine.score(pr);
+      const signal = scored.signals.find(s => s.name === 'review_status');
+      expect(signal?.score).toBe(0);
+    });
   });
 
   describe('body_quality signal', () => {
@@ -307,12 +333,12 @@ describe('ScoringEngine', () => {
       expect(signal?.score).toBe(90);
     });
 
-    it('scores 0 comments as 30', async () => {
+    it('scores 0 comments as 0', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData({ commentCount: 0 });
       const scored = await engine.score(pr);
       const signal = scored.signals.find(s => s.name === 'activity');
-      expect(signal?.score).toBe(30);
+      expect(signal?.score).toBe(0);
     });
   });
 
@@ -361,12 +387,12 @@ describe('ScoringEngine', () => {
       expect(signal?.score).toBe(90);
     });
 
-    it('scores without milestone as 40', async () => {
+    it('scores without milestone as 0', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData({ milestone: undefined });
       const scored = await engine.score(pr);
       const signal = scored.signals.find(s => s.name === 'milestone');
-      expect(signal?.score).toBe(40);
+      expect(signal?.score).toBe(0);
     });
   });
 
@@ -387,22 +413,22 @@ describe('ScoringEngine', () => {
       expect(signal?.score).toBe(30);
     });
 
-    it('scores no labels as 50', async () => {
+    it('scores no labels as 0', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData({ labels: [] });
       const scored = await engine.score(pr);
       const signal = scored.signals.find(s => s.name === 'label_priority');
-      expect(signal?.score).toBe(50);
+      expect(signal?.score).toBe(0);
     });
   });
 
   describe('codeowners signal', () => {
-    it('scores no codeowners as 40', async () => {
+    it('scores no codeowners as 0', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData({ codeowners: [] });
       const scored = await engine.score(pr);
       const signal = scored.signals.find(s => s.name === 'codeowners');
-      expect(signal?.score).toBe(40);
+      expect(signal?.score).toBe(0);
     });
 
     it('scores author as codeowner as 95', async () => {
@@ -423,60 +449,32 @@ describe('ScoringEngine', () => {
       expect(signal?.score).toBe(80);
     });
 
-    it('scores without reviewers as 40', async () => {
+    it('scores without reviewers as 0', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData({ requestedReviewers: [] });
       const scored = await engine.score(pr);
       const signal = scored.signals.find(s => s.name === 'requested_reviewers');
-      expect(signal?.score).toBe(40);
+      expect(signal?.score).toBe(0);
     });
   });
 
   describe('intent signal', () => {
-    it('scores bugfix intent as 90', async () => {
+    it('scores intent as 0 with weight 0 (disabled)', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData({ title: 'fix: resolve auth crash' });
       const scored = await engine.score(pr);
       const intentSignal = scored.signals.find(s => s.name === 'intent');
       expect(intentSignal).toBeDefined();
-      expect(intentSignal!.score).toBe(90);
+      expect(intentSignal!.score).toBe(0);
+      expect(intentSignal!.weight).toBe(0);
       expect(scored.intent).toBe('bugfix');
     });
 
-    it('scores feature intent as 85', async () => {
+    it('still classifies intent correctly', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData({ title: 'feat: add dark mode' });
       const scored = await engine.score(pr);
-      const intentSignal = scored.signals.find(s => s.name === 'intent');
-      expect(intentSignal!.score).toBe(85);
       expect(scored.intent).toBe('feature');
-    });
-
-    it('scores dependency intent as 35', async () => {
-      const engine = new ScoringEngine();
-      const pr = createPRData({ title: 'chore(deps): bump lodash' });
-      const scored = await engine.score(pr);
-      const intentSignal = scored.signals.find(s => s.name === 'intent');
-      expect(intentSignal!.score).toBe(35);
-      expect(scored.intent).toBe('dependency');
-    });
-
-    it('scores docs intent as 30', async () => {
-      const engine = new ScoringEngine();
-      const pr = createPRData({ title: 'docs: update API reference' });
-      const scored = await engine.score(pr);
-      const intentSignal = scored.signals.find(s => s.name === 'intent');
-      expect(intentSignal!.score).toBe(30);
-      expect(scored.intent).toBe('docs');
-    });
-
-    it('scores chore intent as 25', async () => {
-      const engine = new ScoringEngine();
-      const pr = createPRData({ title: 'ci: fix GitHub Actions workflow' });
-      const scored = await engine.score(pr);
-      const intentSignal = scored.signals.find(s => s.name === 'intent');
-      expect(intentSignal!.score).toBe(25);
-      expect(scored.intent).toBe('chore');
     });
 
     it('uses heuristic for non-conventional titles', async () => {
@@ -487,37 +485,238 @@ describe('ScoringEngine', () => {
     });
   });
 
-  describe('LLM integration', () => {
-    it('blends heuristic and LLM scores with 0.4/0.6 ratio', async () => {
+  describe('TOPSIS scoring', () => {
+    it('returns readinessScore on result', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.readinessScore).toBeDefined();
+      expect(typeof scored.readinessScore).toBe('number');
+      expect(scored.readinessScore).toBeGreaterThanOrEqual(0);
+      expect(scored.readinessScore).toBeLessThanOrEqual(100);
+    });
+
+    it('high-quality PR gets high readiness score', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData({
+        ciStatus: 'success',
+        mergeable: 'mergeable',
+        reviewState: 'approved',
+        reviewCount: 2,
+        hasTests: true,
+        hasIssueRef: true,
+        isDraft: false,
+        commentCount: 5,
+      });
+      const scored = await engine.score(pr);
+      expect(scored.readinessScore!).toBeGreaterThan(60);
+    });
+
+    it('low-quality PR gets low readiness score', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData({
+        ciStatus: 'failure',
+        mergeable: 'conflicting',
+        reviewState: 'none',
+        reviewCount: 0,
+        hasTests: false,
+        hasIssueRef: false,
+        isDraft: true,
+        commentCount: 0,
+        additions: 1,
+        deletions: 0,
+        body: 'fix',
+        changedFiles: ['README.md'],
+        codeowners: [],
+        requestedReviewers: [],
+        labels: [],
+        milestone: undefined,
+      });
+      const scored = await engine.score(pr);
+      // CI failure (0.4x) + conflict (0.5x) + draft (0.4x) = very low
+      expect(scored.readinessScore!).toBeLessThan(15);
+    });
+  });
+
+  describe('hard penalty multipliers', () => {
+    it('applies CI failure penalty (0.4x)', async () => {
+      const engine = new ScoringEngine();
+      const goodPr = createPRData({ ciStatus: 'success' });
+      const badPr = createPRData({ ciStatus: 'failure' });
+      const goodScored = await engine.score(goodPr);
+      const badScored = await engine.score(badPr);
+      expect(badScored.penaltyMultiplier).toBeLessThanOrEqual(0.4);
+      expect(badScored.readinessScore!).toBeLessThan(goodScored.readinessScore!);
+    });
+
+    it('applies conflict penalty (0.5x)', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData({ mergeable: 'conflicting' });
+      const scored = await engine.score(pr);
+      expect(scored.penaltyMultiplier).toBeLessThanOrEqual(0.5);
+    });
+
+    it('applies draft penalty (0.4x)', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData({ isDraft: true });
+      const scored = await engine.score(pr);
+      expect(scored.penaltyMultiplier).toBeLessThanOrEqual(0.4);
+    });
+
+    it('stacks penalties: CI fail + spam + draft', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData({
+        ciStatus: 'failure',
+        isDraft: true,
+        additions: 1,
+        deletions: 0,
+        hasIssueRef: false,
+        body: 'fix',
+        changedFiles: ['README.md'],
+        authorAssociation: 'NONE',
+      });
+      const scored = await engine.score(pr);
+      // If spam detected: 0.4 * 0.2 * 0.4 = 0.032
+      if (scored.isSpam) {
+        expect(scored.readinessScore!).toBeLessThan(10);
+      } else {
+        // Even without spam: 0.4 * 0.4 = 0.16
+        expect(scored.readinessScore!).toBeLessThan(20);
+      }
+    });
+
+    it('applies abandoned penalty (0.3x)', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData({
+        ageInDays: 200,
+        commentCount: 0,
+        reviewState: 'none',
+        reviewCount: 0,
+      });
+      const scored = await engine.score(pr);
+      expect(scored.penaltyMultiplier).toBeLessThanOrEqual(0.3);
+    });
+
+    it('no penalty for clean PR', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.penaltyMultiplier).toBe(1.0);
+    });
+  });
+
+  describe('tier classification', () => {
+    it('assigns critical when ideaScore>=80 and readiness>=60', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = '{"score": 85, "risk": "low", "reason": "Critical fix"}';
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData(); // good defaults = high readiness
+      const scored = await engine.score(pr);
+      expect(scored.ideaScore).toBeGreaterThanOrEqual(80);
+      expect(scored.tier).toBe('critical');
+    });
+
+    it('assigns high when ideaScore>=70 but readiness<60', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = '{"score": 80, "risk": "low", "reason": "Good idea"}';
+      const engine = new ScoringEngine(provider);
+      // Draft PR = low readiness due to 0.4x penalty
+      const pr = createPRData({ isDraft: true });
+      const scored = await engine.score(pr);
+      // Draft penalty drops readiness below 60
+      expect(scored.tier).toBe('high');
+    });
+
+    it('assigns normal when ideaScore 45-69', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = '{"score": 55, "risk": "low", "reason": "Routine fix"}';
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.tier).toBe('normal');
+    });
+
+    it('assigns low when ideaScore<45', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = '{"score": 20, "risk": "low", "reason": "Trivial"}';
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.tier).toBe('low');
+    });
+
+    it('uses readinessScore for tier when no LLM', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.tier).toBeDefined();
+      expect(['critical', 'high', 'normal', 'low']).toContain(scored.tier);
+    });
+  });
+
+  describe('dual scoring — LLM integration', () => {
+    it('returns ideaScore from LLM', async () => {
       const provider = new MockLLMProvider();
       provider.generateTextResponse = '{"score": 75, "risk": "low", "reason": "Test"}';
       const engine = new ScoringEngine(provider);
-
       const pr = createPRData();
       const scored = await engine.score(pr);
 
-      // Calculate heuristic score
-      const totalWeight = scored.signals.reduce((sum, s) => sum + s.weight, 0);
-      const heuristicScore = scored.signals.reduce((sum, s) => sum + s.score * s.weight, 0) / totalWeight;
-
-      // Expected: 0.4 * heuristic + 0.6 * 75
-      const expected = Math.round(0.4 * heuristicScore + 0.6 * 75);
-      expect(scored.totalScore).toBe(expected);
+      expect(scored.ideaScore).toBe(75);
+      expect(scored.ideaReason).toBe('Test');
+      // backward compat
       expect(scored.llmScore).toBe(75);
       expect(scored.llmRisk).toBe('low');
     });
 
-    it('uses heuristic-only score when no provider', async () => {
+    it('computes totalScore = 0.7 * ideaScore + 0.3 * readinessScore', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = '{"score": 75, "risk": "low", "reason": "Test"}';
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+
+      const expected = Math.round(0.7 * scored.ideaScore! + 0.3 * scored.readinessScore!);
+      expect(scored.totalScore).toBe(expected);
+    });
+
+    it('uses readinessScore as totalScore when no provider', async () => {
       const engine = new ScoringEngine();
       const pr = createPRData();
       const scored = await engine.score(pr);
 
-      // Calculate heuristic score
-      const totalWeight = scored.signals.reduce((sum, s) => sum + s.weight, 0);
-      const heuristicScore = scored.signals.reduce((sum, s) => sum + s.score * s.weight, 0) / totalWeight;
-
-      expect(scored.totalScore).toBe(Math.round(heuristicScore));
+      expect(scored.totalScore).toBe(scored.readinessScore);
+      expect(scored.ideaScore).toBeUndefined();
       expect(scored.llmScore).toBeUndefined();
+    });
+  });
+
+  describe('percentile rank', () => {
+    it('assigns percentile ranks in scoreMany', async () => {
+      const engine = new ScoringEngine();
+      const prs = [
+        createPRData({ number: 1, ciStatus: 'success', additions: 100 }),
+        createPRData({ number: 2, ciStatus: 'failure', additions: 1, deletions: 0, body: 'x' }),
+        createPRData({ number: 3, ciStatus: 'success', additions: 200 }),
+      ];
+      const scored = await engine.scoreMany(prs);
+      expect(scored.length).toBe(3);
+      // All should have percentileRank
+      for (const s of scored) {
+        expect(s.percentileRank).toBeDefined();
+        expect(s.percentileRank).toBeGreaterThanOrEqual(0);
+        expect(s.percentileRank).toBeLessThanOrEqual(100);
+      }
+      // Lowest score should have percentileRank=0, highest=100
+      expect(scored[0].percentileRank).toBe(0);
+      expect(scored[scored.length - 1].percentileRank).toBe(100);
+    });
+
+    it('assigns 50 for single PR', async () => {
+      const engine = new ScoringEngine();
+      const prs = [createPRData({ number: 1 })];
+      const scored = await engine.scoreMany(prs);
+      expect(scored[0].percentileRank).toBe(50);
     });
   });
 

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -603,8 +603,8 @@ describe('ScoringEngine', () => {
   describe('tier classification', () => {
     it('assigns critical when ideaScore>=80', async () => {
       const provider = new MockLLMProvider();
-      // 8/10 idea → ideaScore=80, 5/5 impl → implScore=100
-      provider.generateTextResponse = dualChecklistResponse(8, 5, 'low', 'Critical fix');
+      // 8/10 idea * 8 + bonus 16 = 80, 5/5 impl → implScore=100
+      provider.generateTextResponse = dualChecklistResponse(8, 5, 'low', 'Critical fix', 16);
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -614,8 +614,8 @@ describe('ScoringEngine', () => {
 
     it('assigns high when ideaScore>=60', async () => {
       const provider = new MockLLMProvider();
-      // 7/10 idea → ideaScore=70
-      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Good idea');
+      // 7/10 idea * 8 + bonus 14 = 70
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Good idea', 14);
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -623,9 +623,10 @@ describe('ScoringEngine', () => {
       expect(scored.tier).toBe('high');
     });
 
-    it('assigns high for exactly 6/10 (ideaScore=60)', async () => {
+    it('assigns high for exactly ideaScore=60', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = dualChecklistResponse(6, 3, 'low', 'Decent fix');
+      // 6/10 idea * 8 + bonus 12 = 60
+      provider.generateTextResponse = dualChecklistResponse(6, 3, 'low', 'Decent fix', 12);
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -635,8 +636,8 @@ describe('ScoringEngine', () => {
 
     it('assigns normal when ideaScore 30-59', async () => {
       const provider = new MockLLMProvider();
-      // 5/10 idea → ideaScore=50
-      provider.generateTextResponse = dualChecklistResponse(5, 3, 'low', 'Routine fix');
+      // 5/10 idea * 8 + bonus 10 = 50
+      provider.generateTextResponse = dualChecklistResponse(5, 3, 'low', 'Routine fix', 10);
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -646,8 +647,8 @@ describe('ScoringEngine', () => {
 
     it('assigns low when ideaScore<30', async () => {
       const provider = new MockLLMProvider();
-      // 2/10 idea → ideaScore=20
-      provider.generateTextResponse = dualChecklistResponse(2, 1, 'low', 'Trivial');
+      // 2/10 idea * 8 + bonus 4 = 20
+      provider.generateTextResponse = dualChecklistResponse(2, 1, 'low', 'Trivial', 4);
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -667,8 +668,8 @@ describe('ScoringEngine', () => {
   describe('dual scoring — idea + implementation', () => {
     it('returns separate ideaScore and implementationScore', async () => {
       const provider = new MockLLMProvider();
-      // 7/10 idea → 70, 4/5 impl → 80
-      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Test');
+      // 7/10 idea * 8 + bonus 14 = 70, 4/5 impl → 80
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Test', 14);
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -687,8 +688,8 @@ describe('ScoringEngine', () => {
 
     it('computes totalScore as 0.7*idea + 0.3*implementation', async () => {
       const provider = new MockLLMProvider();
-      // 7/10 idea → 70, 4/5 impl → 80
-      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Test');
+      // 7/10 idea * 8 + bonus 14 = 70, 4/5 impl → 80
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Test', 14);
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -699,8 +700,8 @@ describe('ScoringEngine', () => {
 
     it('high idea + low implementation = idea-driven total', async () => {
       const provider = new MockLLMProvider();
-      // 8/10 idea → 80, 1/5 impl → 20
-      provider.generateTextResponse = dualChecklistResponse(8, 1, 'medium', 'Great idea, bad code');
+      // 8/10 idea * 8 + bonus 16 = 80, 1/5 impl → 20
+      provider.generateTextResponse = dualChecklistResponse(8, 1, 'medium', 'Great idea, bad code', 16);
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -713,14 +714,47 @@ describe('ScoringEngine', () => {
 
     it('low idea + high implementation = still low total', async () => {
       const provider = new MockLLMProvider();
-      // 1/10 idea → 10, 5/5 impl → 100
-      provider.generateTextResponse = dualChecklistResponse(1, 5, 'low', 'Trivial but polished');
+      // 1/10 idea * 8 + bonus 2 = 10, 5/5 impl → 100
+      provider.generateTextResponse = dualChecklistResponse(1, 5, 'low', 'Trivial but polished', 2);
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
 
       // totalScore = round(0.7 * 10 + 0.3 * 100) = round(7 + 30) = 37
       expect(scored.totalScore).toBe(37);
+    });
+
+    it('noveltyBonus provides fine-grained differentiation', async () => {
+      const provider = new MockLLMProvider();
+      // Same binary (6/10) but different bonus: 6*8+5=53 vs 6*8+15=63
+      provider.generateTextResponse = dualChecklistResponse(6, 4, 'low', 'Low bonus', 5);
+      const engine = new ScoringEngine(provider);
+      const pr1 = createPRData({ number: 1 });
+      const scored1 = await engine.score(pr1);
+
+      provider.generateTextResponse = dualChecklistResponse(6, 4, 'low', 'High bonus', 15);
+      const pr2 = createPRData({ number: 2 });
+      const scored2 = await engine.score(pr2);
+
+      expect(scored1.ideaScore).toBe(53);
+      expect(scored2.ideaScore).toBe(63);
+      expect(scored2.ideaScore! - scored1.ideaScore!).toBe(10);
+    });
+
+    it('noveltyBonus clamped to 0-20 range', async () => {
+      const provider = new MockLLMProvider();
+      // Bonus > 20 should be clamped
+      provider.generateTextResponse = JSON.stringify({
+        idea: [true,true,true,true,true,true,true,true,true,true],
+        implementation: [true,true,true,true,true],
+        noveltyBonus: 30, risk: 'low', reason: 'Over bonus',
+      });
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+
+      // 10*8 + 20(clamped) = 100
+      expect(scored.ideaScore).toBe(100);
     });
 
     it('uses readinessScore as totalScore when no provider', async () => {
@@ -764,7 +798,8 @@ describe('ScoringEngine', () => {
   describe('issue context enrichment', () => {
     it('includes issueContext in LLM prompt when available', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'With context');
+      // 7*8 + 14 = 70
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'With context', 14);
       const engine = new ScoringEngine(provider);
       const pr = createPRData({
         issueContext: 'Bug: login crashes when password contains special chars',
@@ -777,7 +812,8 @@ describe('ScoringEngine', () => {
 
     it('works without issueContext', async () => {
       const provider = new MockLLMProvider();
-      provider.generateTextResponse = dualChecklistResponse(6, 3, 'low', 'No context');
+      // 6*8 + 12 = 60
+      provider.generateTextResponse = dualChecklistResponse(6, 3, 'low', 'No context', 12);
       const engine = new ScoringEngine(provider);
       const pr = createPRData();
       const scored = await engine.score(pr);
@@ -801,16 +837,17 @@ describe('ScoringEngine', () => {
       let callCount = 0;
       provider.generateTextResponse = () => {
         callCount++;
-        // Return different idea scores: 5/10=50, 8/10=80, 7/10=70
+        // Return different idea scores with same bonus=10:
+        // 5*8+10=50, 8*8+10=74, 7*8+10=66
         const ideaYes = [5, 8, 7][callCount - 1] ?? 7;
-        return dualChecklistResponse(ideaYes, 4, 'low', `Pass ${callCount}`);
+        return dualChecklistResponse(ideaYes, 4, 'low', `Pass ${callCount}`, 10);
       };
       const engine = new ScoringEngine(provider, false, 5, 3);
       const pr = createPRData();
       const scored = await engine.score(pr);
       expect(provider.generateTextCalls.length).toBe(3);
-      // Sorted by ideaScore: [50, 70, 80] → median = 70 (7/10)
-      expect(scored.ideaScore).toBe(70);
+      // Sorted by ideaScore: [50, 66, 74] → median = 66 (7*8+10)
+      expect(scored.ideaScore).toBe(66);
     });
 
     it('enforces minimum 1 pass', async () => {
@@ -850,6 +887,211 @@ describe('ScoringEngine', () => {
 
       expect(scored.isSpam).toBe(false);
       expect(scored.spamReasons).toEqual([]);
+    });
+  });
+
+  describe('cascade pipeline', () => {
+    it('skips LLM when readinessScore < preFilterThreshold', async () => {
+      const haiku = new MockLLMProvider();
+      const sonnet = new MockLLMProvider();
+      const engine = new ScoringEngine({
+        provider: haiku,
+        cascade: { enabled: true, reScoreProvider: sonnet, preFilterThreshold: 99 },
+      });
+      // Very low quality PR that gets pre-filtered
+      const pr = createPRData({
+        ciStatus: 'failure',
+        mergeable: 'conflicting',
+        isDraft: true,
+        additions: 1,
+        deletions: 0,
+        body: 'x',
+        hasIssueRef: false,
+        hasTests: false,
+        authorAssociation: 'NONE',
+      });
+      const scored = await engine.score(pr);
+      expect(scored.scoredBy).toBe('heuristic');
+      expect(haiku.generateTextCalls.length).toBe(0);
+      expect(sonnet.generateTextCalls.length).toBe(0);
+      expect(scored.ideaScore).toBeUndefined();
+    });
+
+    it('skips LLM for spam PRs', async () => {
+      const haiku = new MockLLMProvider();
+      const sonnet = new MockLLMProvider();
+      const engine = new ScoringEngine({
+        provider: haiku,
+        cascade: { enabled: true, reScoreProvider: sonnet },
+      });
+      // Spam PR: tiny docs, no issue, short body, NONE author
+      const pr = createPRData({
+        additions: 1,
+        deletions: 0,
+        hasIssueRef: false,
+        body: 'fix',
+        hasTests: false,
+        changedFiles: ['README.md'],
+        authorAssociation: 'NONE',
+      });
+      const scored = await engine.score(pr);
+      expect(scored.scoredBy).toBe('heuristic');
+      expect(haiku.generateTextCalls.length).toBe(0);
+    });
+
+    it('uses only Haiku when ideaScore < haikuThreshold', async () => {
+      const haiku = new MockLLMProvider();
+      const sonnet = new MockLLMProvider();
+      // 2/10 * 8 + bonus 5 = 21 (< 40 threshold)
+      haiku.generateTextResponse = dualChecklistResponse(2, 2, 'low', 'Low value', 5);
+      const engine = new ScoringEngine({
+        provider: haiku,
+        cascade: { enabled: true, reScoreProvider: sonnet, haikuThreshold: 40 },
+      });
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.scoredBy).toBe('haiku');
+      expect(scored.ideaScore).toBe(21);
+      expect(haiku.generateTextCalls.length).toBe(1);
+      expect(sonnet.generateTextCalls.length).toBe(0);
+    });
+
+    it('re-scores with Sonnet when ideaScore >= haikuThreshold', async () => {
+      const haiku = new MockLLMProvider();
+      const sonnet = new MockLLMProvider();
+      // Haiku: 7*8 + 12 = 68 (>= 40 threshold)
+      haiku.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Haiku says good', 12);
+      // Sonnet: 6*8 + 10 = 58 (Sonnet is stricter)
+      sonnet.generateTextResponse = dualChecklistResponse(6, 3, 'medium', 'Sonnet says okay', 10);
+      const engine = new ScoringEngine({
+        provider: haiku,
+        cascade: { enabled: true, reScoreProvider: sonnet, haikuThreshold: 40 },
+      });
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.scoredBy).toBe('sonnet');
+      expect(scored.ideaScore).toBe(58); // Sonnet's score
+      expect(scored.llmReason).toBe('Sonnet says okay');
+      expect(haiku.generateTextCalls.length).toBe(1);
+      expect(sonnet.generateTextCalls.length).toBe(1);
+    });
+
+    it('Sonnet fail falls back to Haiku score', async () => {
+      const haiku = new MockLLMProvider();
+      const sonnet = new MockLLMProvider();
+      // Haiku: 8*8 + 14 = 78
+      haiku.generateTextResponse = dualChecklistResponse(8, 4, 'low', 'Haiku scored', 14);
+      // Sonnet throws
+      sonnet.generateTextResponse = () => { throw new Error('Rate limit'); };
+      const engine = new ScoringEngine({
+        provider: haiku,
+        cascade: { enabled: true, reScoreProvider: sonnet, haikuThreshold: 40 },
+      });
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.scoredBy).toBe('haiku');
+      expect(scored.ideaScore).toBe(78); // Haiku's score preserved
+      expect(scored.llmReason).toBe('Haiku scored');
+    });
+
+    it('Haiku fail falls back to heuristic', async () => {
+      const haiku = new MockLLMProvider();
+      const sonnet = new MockLLMProvider();
+      haiku.generateTextResponse = () => { throw new Error('Service down'); };
+      const engine = new ScoringEngine({
+        provider: haiku,
+        cascade: { enabled: true, reScoreProvider: sonnet },
+      });
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.scoredBy).toBe('heuristic');
+      expect(scored.ideaScore).toBeUndefined();
+      expect(scored.ideaReason).toContain('LLM failed');
+    });
+
+    it('legacy constructor works (cascade disabled by default)', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Legacy', 12);
+      const engine = new ScoringEngine(provider, false, 5);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.scoredBy).toBeUndefined(); // legacy path doesn't set scoredBy
+      expect(scored.ideaScore).toBe(68); // 7*8 + 12
+    });
+
+    it('cascade disabled uses single provider path', async () => {
+      const haiku = new MockLLMProvider();
+      const sonnet = new MockLLMProvider();
+      haiku.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Single path', 12);
+      const engine = new ScoringEngine({
+        provider: haiku,
+        cascade: { enabled: false, reScoreProvider: sonnet },
+      });
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      // cascade disabled → legacy path
+      expect(scored.scoredBy).toBeUndefined();
+      expect(scored.ideaScore).toBe(68);
+      expect(haiku.generateTextCalls.length).toBe(1);
+      expect(sonnet.generateTextCalls.length).toBe(0);
+    });
+  });
+
+  describe('readyToSteal flag', () => {
+    it('true when ideaScore>=70 && implScore>=80 && state=closed', async () => {
+      const provider = new MockLLMProvider();
+      // 8*8 + 14 = 78 idea, 4/5 = 80 impl
+      provider.generateTextResponse = dualChecklistResponse(8, 4, 'low', 'Great PR', 14);
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData({ state: 'closed' });
+      const scored = await engine.score(pr);
+      expect(scored.readyToSteal).toBe(true);
+    });
+
+    it('false for open PRs even with high scores', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = dualChecklistResponse(8, 4, 'low', 'Great PR', 14);
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData({ state: 'open' });
+      const scored = await engine.score(pr);
+      expect(scored.readyToSteal).toBe(false);
+    });
+
+    it('false when ideaScore < 70', async () => {
+      const provider = new MockLLMProvider();
+      // 5*8 + 8 = 48 idea
+      provider.generateTextResponse = dualChecklistResponse(5, 5, 'low', 'Mid PR', 8);
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData({ state: 'closed' });
+      const scored = await engine.score(pr);
+      expect(scored.readyToSteal).toBe(false);
+    });
+
+    it('false when no LLM provider (heuristic only)', async () => {
+      const engine = new ScoringEngine();
+      const pr = createPRData({ state: 'closed' });
+      const scored = await engine.score(pr);
+      expect(scored.readyToSteal).toBe(false);
+    });
+  });
+
+  describe('scoredBy field', () => {
+    it('non-cascade: scoredBy undefined (legacy compat)', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Test', 12);
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.scoredBy).toBeUndefined();
+    });
+
+    it('noveltyBonus field exposed in ScoredPR output', async () => {
+      const provider = new MockLLMProvider();
+      provider.generateTextResponse = dualChecklistResponse(7, 4, 'low', 'Test', 15);
+      const engine = new ScoringEngine(provider);
+      const pr = createPRData();
+      const scored = await engine.score(pr);
+      expect(scored.noveltyBonus).toBe(15);
     });
   });
 });


### PR DESCRIPTION
## Summary
- **Cascade pipeline**: Heuristic pre-filter → Haiku → Sonnet re-score (~$13 vs $27 Sonnet-only)
- **Dual scoring**: ideaScore (10Q CheckEval) + implementationScore (5Q) + readinessScore (TOPSIS)
- `scoredBy`, `readyToSteal`, `noveltyBonus`, `PRData.state` fields
- `CascadeConfig`, `ScoringEngineOptions` types + scanner wiring
- `bulk-score-openclaw.ts`: cascade mode, resume support, OpenAI embedding
- README + CHANGELOG updated for v0.8.0

## Test plan
- [x] 125/125 scoring tests passing (17 new)
- [x] 383 total tests passing (no regressions)
- [x] Legacy constructor backward compat preserved
- [x] Cascade disabled = existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)